### PR TITLE
:arrow_up: add unit testing

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -13,17 +13,15 @@ jobs:
     name: Publish Documentation
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Set up php ${{ matrix.php-version }}
         uses: shivammathur/setup-php@v2
         with:
           php-version: 8.2
-      - uses: ramsey/composer-install@v2
 
       - name: Install and run phpdocumentor
         run: |
-          rm phpDocumentor.phar
           wget https://phpdoc.org/phpDocumentor.phar
           php phpDocumentor.phar run -d ./src -t ./docs/_build
 

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -12,16 +12,13 @@ jobs:
   documentation:
     name: Publish Documentation
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        php-version: ["8.2"]
     steps:
       - uses: actions/checkout@v3
 
       - name: Set up php ${{ matrix.php-version }}
         uses: shivammathur/setup-php@v2
         with:
-          php-version: ${{ matrix.php-version }}
+          php-version: 8.2
 
       - name: Install and run phpdocumentor
         run: |

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -11,7 +11,7 @@ on:
 jobs:
   documentation:
     name: Publish Documentation
-    runs-on: ubuntu-latest
+    runs-on: macos-latest
     steps:
       - uses: actions/checkout@v4
 
@@ -22,8 +22,9 @@ jobs:
 
       - name: Install and run phpdocumentor
         run: |
+          sudo apt remove php-psr
           wget https://phpdoc.org/phpDocumentor.phar
-          php phpDocumentor.phar run -d ./src -t ./docs/_build
+          php phpDocumentor.phar run -d ./src -t ./docs/_build --ignore ./tests
 
       - name: Deploy
         uses: peaceiris/actions-gh-pages@v3

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -23,6 +23,7 @@ jobs:
 
       - name: Install and run phpdocumentor
         run: |
+          rm phpDocumentor.phar
           wget https://phpdoc.org/phpDocumentor.phar
           php phpDocumentor.phar run -d ./src -t ./docs/_build
 

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -23,7 +23,7 @@ jobs:
       - name: Install and run phpdocumentor
         run: |
           wget https://phpdoc.org/phpDocumentor.phar
-          php phpDocumentor.phar run -d ./src -t ./docs/_build --ignore ./tests
+          php phpDocumentor.phar run -d ./src -t ./docs/_build
 
       - name: Deploy
         uses: peaceiris/actions-gh-pages@v3

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -19,6 +19,7 @@ jobs:
         uses: shivammathur/setup-php@v2
         with:
           php-version: 8.2
+      - uses: ramsey/composer-install@v2
 
       - name: Install and run phpdocumentor
         run: |

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -23,7 +23,7 @@ jobs:
         with:
           php-version: ${{ matrix.php-version }}
 
-      - name: Install phpdoc
+      - name: Install and run phpdocumentor
         run: |
           wget https://phpdoc.org/phpDocumentor.phar
           php phpDocumentor.phar run -d ./src -t ./docs/_build

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -22,7 +22,6 @@ jobs:
 
       - name: Install and run phpdocumentor
         run: |
-          sudo apt remove php-psr
           wget https://phpdoc.org/phpDocumentor.phar
           php phpDocumentor.phar run -d ./src -t ./docs/_build --ignore ./tests
 

--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -11,7 +11,7 @@ jobs:
       matrix:
         php-version: ["7.4"]
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
 
     - name: Set up PHP ${{ matrix.php-version }}
       uses: shivammathur/setup-php@v2

--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -1,0 +1,33 @@
+name: Unit tests
+
+on:
+  - push
+
+jobs:
+  phpunit-ubuntu:
+    name: Run Tests
+    timeout-minutes: 30
+    strategy:
+      matrix:
+        os:
+          - "ubuntu-latest"
+          # - "windows-latest" # No composer actions are compatible with windows at the moment.
+        php-version:
+          - 7.4
+          - 8.0
+          - 8.1
+          - 8.2
+          - 8.3
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v3
+      - name: Set up php ${{ matrix.php-version }}
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: ${{ matrix.php-version }}
+      - uses: ramsey/composer-install@v2
+      - name: Unit testing with phpunit
+        env:
+          MINDEE_API_KEY: ${{ secrets.MINDEE_API_KEY_SE_TESTS }}
+        run: |
+          ./vendor/bin/phpunit -c tests/phpunit.xml

--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -20,7 +20,9 @@ jobs:
           - 8.3
     runs-on: ${{ matrix.os }}
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
+        with:
+          submodules: recursive
       - name: Set up php ${{ matrix.php-version }}
         uses: shivammathur/setup-php@v2
         with:

--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -11,6 +11,7 @@ jobs:
       matrix:
         os:
           - "ubuntu-latest"
+          - "macos-latest"
           # - "windows-latest" # No composer actions are compatible with windows at the moment.
         php-version:
           - 7.4

--- a/.gitignore
+++ b/.gitignore
@@ -28,3 +28,4 @@ LocalTest.php
 .phplint-cache
 .phpdoc
 docs/_build
+tests/LocalTestNotUnit.php

--- a/src/Client.php
+++ b/src/Client.php
@@ -44,10 +44,12 @@ class Client
 
     /**
      * Mindee Client.
+     *
+     * @param string|null $apiKey Optional API key. Will fall back to environment variable if not provided.
      */
-    public function __construct()
+    public function __construct(?string $apiKey = null)
     {
-        $this->apiKey = getenv('MINDEE_API_KEY');
+        $this->apiKey = $apiKey ?: getenv('MINDEE_API_KEY');
     }
 
     /**

--- a/src/Client.php
+++ b/src/Client.php
@@ -27,16 +27,16 @@ use Mindee\Parsing\Common\AsyncPredictResponse;
 use Mindee\Parsing\Common\PredictResponse;
 
 /**
- * Default owner for API products.
- *
- * Do not change unless you know what you are doing.
- */
-const DEFAULT_OWNER = 'mindee';
-/**
  * Main entrypoint for Mindee operations.
  */
 class Client
 {
+    /**
+     * Default owner for API products.
+     *
+     * Do not change unless you know what you are doing.
+     */
+    public const DEFAULT_OWNER = 'mindee';
     /**
      * @var string API key for a given client.
      */
@@ -130,14 +130,16 @@ class Client
     /**
      * Cleans the account name.
      *
-     * @param string $accountName Name of the endpoint's owner. Replaced by DEFAULT_OWNER if absent.
+     * @param string $accountName Name of the endpoint's owner. Replaced by self::DEFAULT_OWNER if absent.
      * @return string
      */
     private function cleanAccountName(string $accountName): string
     {
         if (!$accountName || strlen(trim($accountName)) < 1) {
-            error_log("No account name provided for custom build. " . DEFAULT_OWNER . " will be used by default.");
-            return DEFAULT_OWNER;
+            error_log(
+                "No account name provided for custom build. " . self::DEFAULT_OWNER . " will be used by default."
+            );
+            return self::DEFAULT_OWNER;
         }
         return $accountName;
     }
@@ -163,7 +165,7 @@ class Client
                 'Please create an endpoint manually before sending requests to a custom build.'
             );
         }
-        $endpointOwner = DEFAULT_OWNER;
+        $endpointOwner = self::DEFAULT_OWNER;
 
         return $this->constructEndpoint($endpointName, $endpointOwner, $endpointVersion);
     }

--- a/src/Error/MindeeHttpException.php
+++ b/src/Error/MindeeHttpException.php
@@ -121,12 +121,12 @@ class MindeeHttpException extends MindeeException
     }
 
     /**
-     * @param string  $url      Remote URL the error was found on.
-     * @param array   $response Raw server response.
-     * @param integer $code     Error code.
+     * @param string       $url      Remote URL the error was found on.
+     * @param array|string $response Raw server response.
+     * @param integer      $code     Error code.
      * @return MindeeHttpException
      */
-    public static function handleError(string $url, array $response, int $code): MindeeHttpException
+    public static function handleError(string $url, $response, int $code): MindeeHttpException
     {
         $errorObj = MindeeHttpException::createErrorObj($response);
         if ($code >= 400 && $code <= 499) {

--- a/src/Geometry/BBox.php
+++ b/src/Geometry/BBox.php
@@ -57,7 +57,7 @@ class BBox
      *
      * @return float
      */
-    public function getMaX(): float
+    public function getMaxX(): float
     {
         return $this->maxX;
     }

--- a/src/Geometry/BBox.php
+++ b/src/Geometry/BBox.php
@@ -96,17 +96,17 @@ class BBox
             $sequence = $points;
         }
         foreach ($sequence as $point) {
-            if ($this->minX > $point->x) {
-                $this->minX = $point->x;
+            if ($this->minX > $point->getX()) {
+                $this->minX = $point->getX();
             }
-            if ($this->minY > $point->y) {
-                $this->minY = $point->y;
+            if ($this->minY > $point->getY()) {
+                $this->minY = $point->getY();
             }
-            if ($this->maxX < $point->x) {
-                $this->maxX = $point->x;
+            if ($this->maxX < $point->getX()) {
+                $this->maxX = $point->getX();
             }
-            if ($this->maxY < $point->y) {
-                $this->maxY = $point->y;
+            if ($this->maxY < $point->getY()) {
+                $this->maxY = $point->getY();
             }
         }
     }

--- a/src/Geometry/BBoxUtils.php
+++ b/src/Geometry/BBoxUtils.php
@@ -15,7 +15,7 @@ abstract class BBoxUtils
      */
     public static function generateBBoxFromPolygon(?Polygon $polygon): ?BBox
     {
-        if (!$polygon) {
+        if (!$polygon || !$polygon->getCoordinates()) {
             return null;
         }
 
@@ -41,7 +41,9 @@ abstract class BBoxUtils
 
         $merged = $polygons[0];
         foreach ($polygons as $polygon) {
-            $merged = PolygonUtils::merge($merged, $polygon);
+            if ($merged !== $polygon) {
+                $merged = PolygonUtils::merge($merged, $polygon);
+            }
         }
 
         return new BBox(
@@ -68,17 +70,17 @@ abstract class BBoxUtils
         $minY = null;
         $maxY = null;
         foreach ($bboxes as $bbox) {
-            if (!$minX || $minX > $bbox->minX) {
-                $minX = $bbox->minX;
+            if (!$minX || $minX > $bbox->getMinX()) {
+                $minX = $bbox->getMinX();
             }
-            if (!$minY || $minY > $bbox->minY) {
-                $minY = $bbox->minY;
+            if (!$minY || $minY > $bbox->getMinY()) {
+                $minY = $bbox->getMinY();
             }
-            if (!$maxX || $maxX > $bbox->maxX) {
-                $maxX = $bbox->maxX;
+            if (!$maxX || $maxX < $bbox->getMaxX()) {
+                $maxX = $bbox->getMaxX();
             }
-            if (!$maxY || $maxY > $bbox->maxY) {
-                $maxY = $bbox->maxY;
+            if (!$maxY || $maxY < $bbox->getMaxY()) {
+                $maxY = $bbox->getMaxY();
             }
         }
 

--- a/src/Geometry/MinMaxUtils.php
+++ b/src/Geometry/MinMaxUtils.php
@@ -17,7 +17,7 @@ class MinMaxUtils
     {
         $yCoords = [];
         foreach ($points as $point) {
-            $yCoords[] = $point->y;
+            $yCoords[] = $point->getY();
         }
 
         return new MinMax(min($yCoords), max($yCoords));
@@ -33,7 +33,7 @@ class MinMaxUtils
     {
         $xCoords = [];
         foreach ($points as $point) {
-            $xCoords[] = $point->x;
+            $xCoords[] = $point->getX();
         }
 
         return new MinMax(min($xCoords), max($xCoords));

--- a/src/Geometry/PolygonUtils.php
+++ b/src/Geometry/PolygonUtils.php
@@ -158,17 +158,17 @@ abstract class PolygonUtils
      */
     public static function merge(?Polygon $base, ?Polygon $target): Polygon
     {
-        if (!$base && !$target) {
+        if ((!$base || !$base->getCoordinates()) && (!$target || !$target->getCoordinates())) {
             throw new MindeeGeometryException('Cannot merge two empty polygons.');
         }
-        if (!$base) {
+        if (!$base || !$base->getCoordinates()) {
             return $target;
         }
-        if (!$target) {
+        if (!$target || !$target->getCoordinates()) {
             return $base;
         }
 
-        return new Polygon(array_unique(array_merge($base->getCoordinates(), $target->getCoordinates())));
+        return new Polygon(array_unique(array_merge($base->getCoordinates(), $target->getCoordinates()), SORT_REGULAR));
     }
 
     /**

--- a/src/Http/MindeeApi.php
+++ b/src/Http/MindeeApi.php
@@ -6,6 +6,7 @@
 
 namespace Mindee\Http;
 
+use Mindee\Client;
 use Mindee\Error\MindeeException;
 
 use const Mindee\VERSION;
@@ -138,8 +139,12 @@ class MindeeApi
      * @param string      $version      Version of the endpoint.
      * @throws \Mindee\Error\MindeeException Throws if the API key specified is invalid.
      */
-    public function __construct(?string $apiKey, string $endpointName, string $accountName, string $version)
-    {
+    public function __construct(
+        ?string $apiKey,
+        string $endpointName,
+        ?string $accountName = Client::DEFAULT_OWNER,
+        ?string $version = "1"
+    ) {
         $this->setApiKey($apiKey);
         if (!$this->apiKey) {
             throw new MindeeException(

--- a/src/Input/LocalInputSource.php
+++ b/src/Input/LocalInputSource.php
@@ -122,6 +122,7 @@ abstract class LocalInputSource extends InputSource
     /**
      * Reads the contents of the file.
      *
+     * @param boolean $closeFile Whether to close the file after parsing it.
      * @return array
      */
     public function readContents(bool $closeFile = true): array

--- a/src/Input/LocalInputSource.php
+++ b/src/Input/LocalInputSource.php
@@ -118,4 +118,19 @@ abstract class LocalInputSource extends InputSource
     public function isPDFEmpty() // TODO: add PDF lib
     {
     }
+
+    /**
+     * Reads the contents of the file.
+     *
+     * @return array
+     */
+    public function readContents(bool $closeFile = true): array
+    {
+        $fileHandle = fopen($this->fileObject->getFilename(), 'rb');
+        $strContents = fread($fileHandle, filesize($this->fileObject->getFilename()));
+        if ($closeFile) {
+            fclose($fileHandle);
+        }
+        return [basename($this->fileObject->getFilename()), $strContents];
+    }
 }

--- a/src/Parsing/Common/Document.php
+++ b/src/Parsing/Common/Document.php
@@ -68,7 +68,7 @@ class Document
         return "########
 Document
 ########
-Mindee ID: $this->id
+:Mindee ID: $this->id
 :Filename: $this->filename
 
 $this->inference";

--- a/src/Parsing/Common/Extras/CropperExtra.php
+++ b/src/Parsing/Common/Extras/CropperExtra.php
@@ -16,7 +16,7 @@ class CropperExtra
 
     /**
      * @param array        $rawPrediction Raw prediction array.
-     * @param integer|null $pageId        Page number for multi pages PDF.
+     * @param integer|null $pageId        Page number for multi pages document.
      */
     public function __construct(array $rawPrediction, ?int $pageId = null)
     {

--- a/src/Parsing/Common/Inference.php
+++ b/src/Parsing/Common/Inference.php
@@ -66,7 +66,7 @@ abstract class Inference
         if (count($this->pages)) {
             $pagesStr = "\nPage Predictions\n================\n\n" . implode(
                 "\n",
-                array_map(fn($page) => strval($page), $this->pages)
+                array_map(fn ($page) => strval($page), $this->pages)
             );
         }
 

--- a/src/Parsing/Common/Inference.php
+++ b/src/Parsing/Common/Inference.php
@@ -40,7 +40,7 @@ abstract class Inference
 
     /**
      * @param array        $rawInference Raw inference array.
-     * @param integer|null $pageId       Page number for multi pages PDF.
+     * @param integer|null $pageId       Page number for multi pages document.
      */
     public function __construct(array $rawInference, ?int $pageId = null)
     {
@@ -62,6 +62,13 @@ abstract class Inference
     {
         $rotationApplied = $this->isRotationApplied ? 'Yes' : 'No';
         $pages = $this->pages ? "\n" . implode("\n", $this->pages) : '';
+        $pagesStr = "";
+        if (count($this->pages)) {
+            $pagesStr = "\nPage Predictions\n================\n\n" . implode(
+                "\n",
+                array_map(fn($page) => strval($page), $this->pages)
+            );
+        }
 
         return "Inference
 #########
@@ -70,7 +77,6 @@ abstract class Inference
 
 Prediction
 ==========
-$this->prediction
-$pages";
+$this->prediction$pagesStr";
     }
 }

--- a/src/Parsing/Common/Job.php
+++ b/src/Parsing/Common/Job.php
@@ -12,25 +12,25 @@ use Mindee\Error\MindeeApiException;
 class Job
 {
     /**
-     * @var string ID of the job sent by the API in response to an enqueue request.
+     * @var string|null ID of the job sent by the API in response to an enqueue request.
      */
-    public string $id;
+    public ?string $id;
     /**
-     * @var \DateTimeImmutable Timestamp of the request reception by the API.
+     * @var \DateTimeImmutable|null Timestamp of the request reception by the API.
      */
-    public \DateTimeImmutable $issuedAt;
+    public ?\DateTimeImmutable $issuedAt;
     /**
-     * @var \DateTimeImmutable Timestamp of the request after it has been completed.
+     * @var \DateTimeImmutable|null Timestamp of the request after it has been completed.
      */
-    public \DateTimeImmutable $availableAt;
+    public ?\DateTimeImmutable $availableAt;
     /**
-     * @var string Status of the request, as seen by the API.
+     * @var string|null Status of the request, as seen by the API.
      */
-    public string $status;
+    public ?string $status;
     /**
-     * @var integer Time (ms) taken for the request to be processed by the API.
+     * @var integer|null Time (ms) taken for the request to be processed by the API.
      */
-    public int $millisecsTaken;
+    public ?int $millisecsTaken;
 
     /**
      * @param array $rawResponse Raw prediction array.
@@ -49,19 +49,22 @@ class Job
         }
         $this->id = $rawResponse['id'];
         $this->status = $rawResponse['status'];
-        if (array_key_exists('available_at', $rawResponse)) {
+        if (array_key_exists('available_at', $rawResponse) && strtotime($rawResponse['available_at'])) {
             try {
                 $this->availableAt = new \DateTimeImmutable($rawResponse['available_at']);
             } catch (\Exception $e) {
                 try {
                     $this->availableAt = new \DateTimeImmutable(strtotime($rawResponse['available_at']));
                 } catch (\Exception $e2) {
-                    throw new MindeeApiException("Could not create date from " . $rawResponse['issued_at']);
+                    throw new MindeeApiException("Could not create date from " . $rawResponse['available_at']);
                 }
             }
             $ts1 = (int)$this->availableAt->format('Uv');
             $ts2 = (int)$this->issuedAt->format('Uv');
             $this->millisecsTaken = $ts2 - $ts1;
+        } else {
+            $this->availableAt = null;
+            $this->millisecsTaken = null;
         }
     }
 

--- a/src/Parsing/Common/Ocr/OcrLine.php
+++ b/src/Parsing/Common/Ocr/OcrLine.php
@@ -27,7 +27,7 @@ class OcrLine
      */
     public function sortOnX()
     {
-        usort($this->words, "Mindee\\Parsing\\Common\\Ocr\\OcrPage::getMinMaxY");
+        usort($this->words, "Mindee\\Parsing\\Common\\Ocr\\OcrPage::getMinMaxX");
     }
 
     /**

--- a/src/Parsing/Common/Ocr/OcrPage.php
+++ b/src/Parsing/Common/Ocr/OcrPage.php
@@ -34,13 +34,30 @@ class OcrPage
     }
 
     /**
+     * Compares word positions on the X axis. Returns a sort-compliant result (0;-1;1).
+     *
+     * @param \Mindee\Parsing\Common\Ocr\OcrWord $word1 First word.
+     * @param \Mindee\Parsing\Common\Ocr\OcrWord $word2 Second word.
+     * @return integer
+     */
+    public static function getMinMaxX(OcrWord $word1, OcrWord $word2): int
+    {
+        $word1X = MinMaxUtils::getMinMaxX($word1->polygon->getCoordinates())->getMin();
+        $word2X = MinMaxUtils::getMinMaxX($word2->polygon->getCoordinates())->getMin();
+        if ($word1X == $word2X) {
+            return 0;
+        }
+        return $word1X < $word2X ? -1 : 1;
+    }
+
+    /**
      * Compares word positions on the Y axis. Returns a sort-compliant result (0;-1;1).
      *
      * @param \Mindee\Parsing\Common\Ocr\OcrWord $word1 First word.
      * @param \Mindee\Parsing\Common\Ocr\OcrWord $word2 Second word.
      * @return integer
      */
-    private static function getMinMaxY(OcrWord $word1, OcrWord $word2): int
+    public static function getMinMaxY(OcrWord $word1, OcrWord $word2): int
     {
         $word1Y = MinMaxUtils::getMinMaxY($word1->polygon->getCoordinates())->getMin();
         $word2Y = MinMaxUtils::getMinMaxY($word2->polygon->getCoordinates())->getMin();
@@ -94,7 +111,7 @@ class OcrPage
      */
     public function getAllLines(): array
     {
-        if (!$this->lines) {
+        if (!isset($this->lines)) {
             $this->lines = $this->toLines();
         }
         return $this->lines;

--- a/src/Parsing/Common/OrientationField.php
+++ b/src/Parsing/Common/OrientationField.php
@@ -16,7 +16,7 @@ class OrientationField extends BaseField
 
     /**
      * @param array        $rawPrediction Raw prediction array.
-     * @param integer|null $pageId        Page number for multi pages PDF.
+     * @param integer|null $pageId        Page number for multi pages document.
      * @param boolean      $reconstructed Whether the field was reconstructed.
      * @param string       $valueKey      Key to use for the value.
      */

--- a/src/Parsing/Common/Page.php
+++ b/src/Parsing/Common/Page.php
@@ -59,7 +59,6 @@ class Page
 
         return "$title
 $dashes
-$this->prediction
-";
+$this->prediction";
     }
 }

--- a/src/Parsing/Custom/CustomLine.php
+++ b/src/Parsing/Custom/CustomLine.php
@@ -32,7 +32,7 @@ class CustomLine
         int $rowNumber
     ) {
         $this->rowNumber = $rowNumber;
-        $this->bbox = new BBox(1, 1, 0, 0);
+        $this->bbox = new BBox(1, 0, 1, 0);
         $this->fields = [];
     }
 
@@ -49,7 +49,7 @@ class CustomLine
             $existingField = $this->fields[$fieldName];
             $existingContent = $existingField->content;
             $mergedContent = '';
-            if (count($existingContent) > 0) {
+            if (strlen($existingContent) > 0) {
                 $mergedContent .= $existingContent . ' ';
             }
             $mergedContent .= $fieldValue->content;
@@ -154,12 +154,12 @@ class CustomLine
         array $fields
     ): string {
         $anchor = '';
-        $fieldAnchor = 0;
-        foreach ($anchors as $fieldAnchor) {
-            $values = $fields[$fieldAnchor]->values;
-            if ($values && count($values) > $fieldAnchor) {
-                $fieldAnchor = count($values);
-                $anchor = $fieldAnchor;
+        $anchorRows = 0;
+        foreach ($anchors as $field) {
+            $values = $fields[$field]->values;
+            if ($values && count($values) > $anchorRows) {
+                $anchorRows = count($values);
+                $anchor = $field;
             }
         }
 
@@ -184,7 +184,7 @@ class CustomLine
         $lineItems = [];
         $fieldsToTransform = [];
         foreach ($fields as $fieldName => $fieldValue) {
-            if (array_key_exists($fieldName, $fieldNames)) {
+            if (in_array($fieldName, $fieldNames)) {
                 $fieldsToTransform[$fieldName] = $fieldValue;
             }
         }
@@ -204,12 +204,12 @@ class CustomLine
         foreach ($linesPrepared as $currentLine) {
             foreach ($fieldsToTransform as $fieldName => $field) {
                 foreach ($field->values as $listFieldValue) {
-                    $minMaxY = MinMaxUtils::getMinMaxY($listFieldValue->polygon);
+                    $minMaxY = MinMaxUtils::getMinMaxY($listFieldValue->polygon->getCoordinates());
                     if (
-                        abs($minMaxY->getMax() - $currentLine->bbox->y_max) <=
-                        $heightLineTolerance &&
-                        abs($minMaxY->getMin() - $currentLine->bbox->y_min) <=
-                        $heightLineTolerance
+                        (abs($minMaxY->getMax() - $currentLine->bbox->getMaxY()) <=
+                            $heightLineTolerance) &&
+                        (abs($minMaxY->getMin() - $currentLine->bbox->getMinY()) <=
+                            $heightLineTolerance)
                     ) {
                         $currentLine->updateField($fieldName, $listFieldValue);
                     }

--- a/src/Parsing/Custom/ListField.php
+++ b/src/Parsing/Custom/ListField.php
@@ -21,8 +21,9 @@ class ListField
     public array $values;
 
     /**
-     * @param array   $rawPrediction Raw prediction array.
-     * @param boolean $reconstructed Whether the field has been reconstructed.
+     * @param array        $rawPrediction Raw prediction array.
+     * @param boolean      $reconstructed Whether the field has been reconstructed.
+     * @param integer|null $pageId        Page number for multi pages document.
      */
     public function __construct(array $rawPrediction, bool $reconstructed = false, ?int $pageId = null)
     {
@@ -31,7 +32,7 @@ class ListField
 
         if (array_key_exists("values", $rawPrediction)) {
             foreach ($rawPrediction['values'] as $value) {
-                if (array_key_exists("page_id", $value)){
+                if (array_key_exists("page_id", $value)) {
                     $pageId = $value["page_id"];
                 }
                 $this->values[] = new ListFieldValue($value, $pageId);

--- a/src/Parsing/Custom/ListField.php
+++ b/src/Parsing/Custom/ListField.php
@@ -24,13 +24,18 @@ class ListField
      * @param array   $rawPrediction Raw prediction array.
      * @param boolean $reconstructed Whether the field has been reconstructed.
      */
-    public function __construct(array $rawPrediction, bool $reconstructed = false)
+    public function __construct(array $rawPrediction, bool $reconstructed = false, ?int $pageId = null)
     {
         $this->values = [];
         $this->reconstructed = $reconstructed;
 
-        foreach ($rawPrediction['value'] as $value) {
-            $this->values[] = new ListFieldValue($value);
+        if (array_key_exists("values", $rawPrediction)) {
+            foreach ($rawPrediction['values'] as $value) {
+                if (array_key_exists("page_id", $value)){
+                    $pageId = $value["page_id"];
+                }
+                $this->values[] = new ListFieldValue($value, $pageId);
+            }
         }
         $this->confidence = 0.0;
     }

--- a/src/Parsing/Custom/ListFieldValue.php
+++ b/src/Parsing/Custom/ListFieldValue.php
@@ -21,7 +21,7 @@ class ListFieldValue
      */
     public float $confidence;
     /**
-     * @var int|null Page number for multi pages document.
+     * @var integer|null Page number for multi pages document.
      */
     private ?int $pageId;
 

--- a/src/Parsing/Custom/ListFieldValue.php
+++ b/src/Parsing/Custom/ListFieldValue.php
@@ -20,16 +20,23 @@ class ListFieldValue
      * @var float|mixed Confidence score.
      */
     public float $confidence;
+    /**
+     * @var int|null Page number for multi pages document.
+     */
+    private ?int $pageId;
 
 
     /**
-     * @param array $rawPrediction Raw prediction array.
+     * @param array        $rawPrediction Raw prediction array.
+     * @param integer|null $pageId        Page number for multi pages document.
      */
     public function __construct(
-        array $rawPrediction
+        array $rawPrediction,
+        ?int $pageId = null
     ) {
-        $this->content    = $rawPrediction['content'];
+        $this->content = $rawPrediction['content'];
         $this->confidence = $rawPrediction['confidence'];
+        $this->pageId = $pageId;
         $this->setPosition($rawPrediction);
     }
 

--- a/src/Parsing/Standard/AmountField.php
+++ b/src/Parsing/Standard/AmountField.php
@@ -18,7 +18,7 @@ class AmountField extends BaseField
 
     /**
      * @param array        $rawPrediction Raw prediction array.
-     * @param integer|null $pageId        Page number for multi pages PDF.
+     * @param integer|null $pageId        Page number for multi pages document.
      * @param boolean      $reconstructed Whether the field was reconstructed.
      */
     public function __construct(

--- a/src/Parsing/Standard/AmountField.php
+++ b/src/Parsing/Standard/AmountField.php
@@ -27,7 +27,7 @@ class AmountField extends BaseField
         bool $reconstructed = false
     ) {
         parent::__construct($rawPrediction, $pageId, $reconstructed, 'value');
-        if (array_key_exists('value', $rawPrediction) && is_float($rawPrediction['value'])) {
+        if (array_key_exists('value', $rawPrediction) && is_numeric($rawPrediction['value'])) {
             $this->value = round(floatval($rawPrediction['value']), 3);
         } else {
             $this->value = null;

--- a/src/Parsing/Standard/BaseField.php
+++ b/src/Parsing/Standard/BaseField.php
@@ -30,7 +30,7 @@ abstract class BaseField
 
     /**
      * @param array        $rawPrediction Raw prediction array.
-     * @param integer|null $pageId        Page number for multi pages PDF.
+     * @param integer|null $pageId        Page number for multi pages document.
      * @param boolean      $reconstructed Whether the field was reconstructed.
      * @param string       $valueKey      Key to use for the value.
      */

--- a/src/Parsing/Standard/ClassificationField.php
+++ b/src/Parsing/Standard/ClassificationField.php
@@ -18,7 +18,7 @@ class ClassificationField extends BaseField
 
     /**
      * @param array        $rawPrediction Raw prediction array.
-     * @param integer|null $pageId        Page number for multi pages PDF.
+     * @param integer|null $pageId        Page number for multi pages document.
      * @param boolean      $reconstructed Whether the field was reconstructed.
      * @param string       $valueKey      Key to use for the value.
      */

--- a/src/Parsing/Standard/CompanyRegistrationField.php
+++ b/src/Parsing/Standard/CompanyRegistrationField.php
@@ -17,7 +17,7 @@ class CompanyRegistrationField extends BaseField
 
     /**
      * @param array        $rawPrediction Raw prediction array.
-     * @param integer|null $pageId        Page number for multi pages PDF.
+     * @param integer|null $pageId        Page number for multi pages document.
      * @param boolean      $reconstructed Whether the field was reconstructed.
      * @param string       $valueKey      Key to use for the value.
      */

--- a/src/Parsing/Standard/DateField.php
+++ b/src/Parsing/Standard/DateField.php
@@ -26,7 +26,7 @@ class DateField extends BaseField
 
     /**
      * @param array        $rawPrediction Raw prediction array.
-     * @param integer|null $pageId        Page number for multi pages PDF.
+     * @param integer|null $pageId        Page number for multi pages document.
      * @param boolean      $reconstructed Whether the field was reconstructed.
      * @param string       $valueKey      Key to use for the value.
      * @throws \Mindee\Error\MindeeApiException Throws if the date can't be created from the given value.

--- a/src/Parsing/Standard/FieldPositionMixin.php
+++ b/src/Parsing/Standard/FieldPositionMixin.php
@@ -30,7 +30,7 @@ trait FieldPositionMixin
     {
         $this->boundingBox = null;
         $this->polygon = new Polygon();
-        if (array_key_exists('polygon', $rawPrediction)) {
+        if (array_key_exists('polygon', $rawPrediction) and isset($rawPrediction['polygon'])) {
             $points = [];
             foreach ($rawPrediction['polygon'] as $point) {
                 $points[] = new Point($point[0], $point[1]);

--- a/src/Parsing/Standard/LocaleField.php
+++ b/src/Parsing/Standard/LocaleField.php
@@ -36,7 +36,7 @@ class LocaleField extends BaseField
 
     /**
      * @param array        $rawPrediction Raw prediction array.
-     * @param integer|null $pageId        Page number for multi pages PDF.
+     * @param integer|null $pageId        Page number for multi pages document.
      * @param boolean      $reconstructed Whether the field was reconstructed.
      */
     public function __construct(

--- a/src/Parsing/Standard/PaymentDetailsField.php
+++ b/src/Parsing/Standard/PaymentDetailsField.php
@@ -52,7 +52,7 @@ class PaymentDetailsField extends BaseField
 
     /**
      * @param array        $rawPrediction    Raw prediction array.
-     * @param integer|null $pageId           Page number for multi pages PDF.
+     * @param integer|null $pageId           Page number for multi pages document.
      * @param boolean      $reconstructed    Whether the field was reconstructed.
      * @param string       $valueKey         Key to use for the value.
      * @param string       $accountNumberKey Key to use for the account number.

--- a/src/Parsing/Standard/PositionField.php
+++ b/src/Parsing/Standard/PositionField.php
@@ -58,12 +58,7 @@ class PositionField extends BaseField
     private static function getPolygon(array $rawPrediction, string $key): ?Polygon
     {
         if (array_key_exists($key, $rawPrediction)) {
-            $polygon = $rawPrediction[$key];
-            try {
-                PolygonUtils::polygonFromPrediction($polygon);
-            } catch (MindeeGeometryException $exc) {
-                return null;
-            }
+            return PolygonUtils::polygonFromPrediction($rawPrediction[$key]);
         }
 
         return null;

--- a/src/Parsing/Standard/StringField.php
+++ b/src/Parsing/Standard/StringField.php
@@ -18,7 +18,7 @@ class StringField extends BaseField
 
     /**
      * @param array        $rawPrediction Raw prediction array.
-     * @param integer|null $pageId        Page number for multi pages PDF.
+     * @param integer|null $pageId        Page number for multi pages document.
      * @param boolean      $reconstructed Whether the field was reconstructed.
      * @param string       $valueKey      Key to use for the value.
      */

--- a/src/Parsing/Standard/TaxField.php
+++ b/src/Parsing/Standard/TaxField.php
@@ -78,9 +78,9 @@ class TaxField extends BaseField
     {
         return [
             'code' => $this->code ?? '',
-            'basis' => strval($this->basis),
-            'rate' => strval($this->rate),
-            'value' => strval($this->value),
+            'basis' => isset($this->basis) ? number_format((float)$this->basis, 2, ".", "") : null,
+            'rate' => isset($this->rate) ? number_format((float)$this->rate, 2, ".", "") : null,
+            'value' => isset($this->value) ? number_format((float)$this->value, 2, ".", "") : null,
         ];
     }
 
@@ -106,9 +106,11 @@ class TaxField extends BaseField
     {
         $printable = $this->printableValues();
 
-        return 'Base: ' . $printable['basis'] . '. ,' .
+        return rtrim(
+            'Base: ' . $printable['basis'] . ', ' .
             'Code: ' . $printable['code'] . ', ' .
             'Rate (%): ' . $printable['rate'] . ', ' .
-            'Amount: ' . $printable['value'] . ', ';
+            'Amount: ' . $printable['value']
+        );
     }
 }

--- a/src/Parsing/Standard/Taxes.php
+++ b/src/Parsing/Standard/Taxes.php
@@ -53,6 +53,6 @@ class Taxes extends \ArrayObject
         }
         $outStr .= implode("\n", $arr);
 
-        return $outStr;
+        return rtrim($outStr);
     }
 }

--- a/src/Product/Custom/CustomV1Document.php
+++ b/src/Product/Custom/CustomV1Document.php
@@ -3,6 +3,7 @@
 namespace Mindee\Product\Custom;
 
 use Mindee\Parsing\Common\Prediction;
+use Mindee\Parsing\Common\SummaryHelper;
 use Mindee\Parsing\Custom\ClassificationField;
 use Mindee\Parsing\Custom\CustomLine;
 use Mindee\Parsing\Custom\ListField;
@@ -66,8 +67,8 @@ class CustomV1Document extends Prediction
             $outStr .= ":$classificationName: $classificationValue\n";
         }
         foreach ($this->fields as $fieldName => $fieldValue) {
-            $outStr .= ":$fieldName: $$fieldValue\n";
+            $outStr .= ":$fieldName: $fieldValue\n";
         }
-        return trim($outStr);
+        return SummaryHelper::cleanOutString($outStr);
     }
 }

--- a/src/Product/Custom/CustomV1Page.php
+++ b/src/Product/Custom/CustomV1Page.php
@@ -3,12 +3,13 @@
 namespace Mindee\Product\Custom;
 
 use Mindee\Parsing\Common\Prediction;
+use Mindee\Parsing\Common\SummaryHelper;
 use Mindee\Parsing\Custom\ListField;
 
 /**
  * Custom V1 page prediction results.
  */
-class CustomV1Page extends Prediction
+class CustomV1Page extends CustomV1Document
 {
     /**
      * @var array Dictionary of all fields in the document.
@@ -17,9 +18,11 @@ class CustomV1Page extends Prediction
 
     /**
      * @param array $rawPrediction Dictionary containing the JSON document response.
+     * @param integer|null $pageId Page number for multi pages document.
      */
-    public function __construct(array $rawPrediction)
+    public function __construct(array $rawPrediction, ?int $pageId=null)
     {
+        parent::__construct($rawPrediction, $pageId);
         $this->fields = [];
         foreach ($rawPrediction as $fieldName => $fieldContents) {
             $this->fields[$fieldName] = new ListField($fieldContents);
@@ -35,6 +38,6 @@ class CustomV1Page extends Prediction
         foreach ($this->fields as $fieldName => $fieldValue) {
             $outStr .= ":$fieldName: $fieldValue\n";
         }
-        return trim($outStr);
+        return SummaryHelper::cleanOutString($outStr);
     }
 }

--- a/src/Product/Custom/CustomV1Page.php
+++ b/src/Product/Custom/CustomV1Page.php
@@ -17,10 +17,10 @@ class CustomV1Page extends CustomV1Document
     public array $fields;
 
     /**
-     * @param array $rawPrediction Dictionary containing the JSON document response.
-     * @param integer|null $pageId Page number for multi pages document.
+     * @param array        $rawPrediction Dictionary containing the JSON document response.
+     * @param integer|null $pageId        Page number for multi pages document.
      */
-    public function __construct(array $rawPrediction, ?int $pageId=null)
+    public function __construct(array $rawPrediction, ?int $pageId = null)
     {
         parent::__construct($rawPrediction, $pageId);
         $this->fields = [];

--- a/src/Product/Fr/IdCard/IdCardV1Document.php
+++ b/src/Product/Fr/IdCard/IdCardV1Document.php
@@ -54,7 +54,7 @@ class IdCardV1Document extends Prediction
 
     /**
      * @param array        $rawPrediction Raw prediction from HTTP response.
-     * @param integer|null $pageId        Page number for multi pages pdf input.
+     * @param integer|null $pageId        Page number for multi pages document.
      */
     public function __construct(array $rawPrediction, ?int $pageId = null)
     {

--- a/src/Product/Fr/IdCard/IdCardV1Page.php
+++ b/src/Product/Fr/IdCard/IdCardV1Page.php
@@ -16,7 +16,7 @@ class IdCardV1Page extends IdCardV1Document
 
     /**
      * @param array        $rawPrediction Raw prediction from HTTP response.
-     * @param integer|null $pageId        Page number for multi pages pdf input.
+     * @param integer|null $pageId        Page number for multi pages document.
      */
     public function __construct(array $rawPrediction, ?int $pageId = null)
     {

--- a/src/Product/Invoice/InvoiceV4Document.php
+++ b/src/Product/Invoice/InvoiceV4Document.php
@@ -89,7 +89,7 @@ class InvoiceV4Document extends Prediction
     public AmountField $totalNet;
     /**
      * @param array        $rawPrediction Raw prediction from HTTP response.
-     * @param integer|null $pageId        Page number for multi pages PDF.
+     * @param integer|null $pageId        Page number for multi pages document.
      */
     public function __construct(array $rawPrediction, ?int $pageId = null)
     {

--- a/src/Product/Invoice/InvoiceV4LineItem.php
+++ b/src/Product/Invoice/InvoiceV4LineItem.php
@@ -49,7 +49,7 @@ class InvoiceV4LineItem
 
     /**
      * @param array        $rawPrediction Array containing the JSON document response.
-     * @param integer|null $pageId        Page number for multi pages PDF.
+     * @param integer|null $pageId        Page number for multi pages document.
      */
     public function __construct(array $rawPrediction, ?int $pageId)
     {

--- a/src/Product/Invoice/InvoiceV4LineItems.php
+++ b/src/Product/Invoice/InvoiceV4LineItems.php
@@ -9,7 +9,7 @@ class InvoiceV4LineItems extends \ArrayObject
 {
     /**
      * @param array        $rawPrediction Raw prediction array.
-     * @param integer|null $pageId        Page number for multi pages PDF.
+     * @param integer|null $pageId        Page number for multi pages document.
      */
     public function __construct(array $rawPrediction, ?int $pageId = null)
     {

--- a/src/Product/Invoice/InvoiceV4LineItems.php
+++ b/src/Product/Invoice/InvoiceV4LineItems.php
@@ -14,7 +14,7 @@ class InvoiceV4LineItems extends \ArrayObject
     public function __construct(array $rawPrediction, ?int $pageId = null)
     {
         $entries = [];
-        foreach ($rawPrediction["line_items"] as $entry) {
+        foreach ($rawPrediction as $entry) {
             $entries[] = new InvoiceV4LineItem($entry, $pageId);
         }
         parent::__construct($entries);

--- a/tests/ClientTest.php
+++ b/tests/ClientTest.php
@@ -1,0 +1,93 @@
+<?php
+
+use Mindee\Client;
+use Mindee\Error\MindeeApiException;
+use Mindee\Error\MindeeClientException;
+use Mindee\Error\MindeeHttpClientException;
+use Mindee\Error\MindeeHttpException;
+use Mindee\Input\EnqueueAndParseMethodOptions;
+use Mindee\Input\PredictMethodOptions;
+use Mindee\Product\Custom\CustomV1;
+use Mindee\Product\Invoice\InvoiceV4;
+use Mindee\Product\InvoiceSplitter\InvoiceSplitterV1;
+use PHPUnit\Framework\TestCase;
+
+use const Mindee\Http\API_KEY_ENV_NAME;
+
+class ClientTest extends TestCase
+{
+    private Client $emptyClient;
+    private Client $dummyClient;
+    private Client $envClient;
+    private string $fileTypesDir;
+
+
+    protected function setUp(): void
+    {
+        $this->dummyClient = new Client("dummy-key");
+        putenv('MINDEE_API_KEY' . '=');
+        $this->emptyClient = new Client();
+        putenv('MINDEE_API_KEY' . '=dummy-env-key');
+        $this->envClient = new Client();
+        $this->fileTypesDir = (
+            getenv('GITHUB_WORKSPACE') ?: "."
+        ) . "/tests/resources/file_types/";
+    }
+
+    public function testParsePathWithoutToken()
+    {
+        $this->expectException(MindeeHttpClientException::class);
+
+        $inputDoc = $this->emptyClient->sourceFromPath($this->fileTypesDir . "pdf/blank.pdf");
+        $this->emptyClient->parse(InvoiceV4::class, $inputDoc);
+    }
+
+    public function testParsePathWithEnvToken()
+    {
+        $this->expectException(MindeeHttpException::class);
+
+        $inputDoc = $this->envClient->sourceFromPath($this->fileTypesDir . "pdf/blank.pdf");
+        $this->envClient->parse(InvoiceV4::class, $inputDoc);
+    }
+
+    public function testParsePathWithWrongFileType()
+    {
+        $this->expectException(Mindee\Error\MindeeMimeTypeException::class);
+
+        $inputDoc = $this->dummyClient->sourceFromPath($this->fileTypesDir . "receipt.txt");
+        ;
+    }
+
+    public function testParsePathWithWrongToken()
+    {
+        $this->expectException(MindeeHttpClientException::class);
+
+        $inputDoc = $this->dummyClient->sourceFromPath($this->fileTypesDir . "pdf/blank.pdf");
+        $this->dummyClient->parse(InvoiceV4::class, $inputDoc);
+    }
+
+    public function testInterfaceVersion()
+    {
+        $dummyEndpoint = $this->dummyClient->createEndpoint("dummy", "dummy", "1.1");
+        $inputDoc = $this->dummyClient->sourceFromPath($this->fileTypesDir . "pdf/blank.pdf");
+        $predictOptions = new PredictMethodOptions();
+        $this->assertEquals("1.1", $dummyEndpoint->settings->version);
+
+        $this->expectException(MindeeHTTPClientException::class);
+        $this->dummyClient->parse(CustomV1::class, $inputDoc, $predictOptions->setEndpoint($dummyEndpoint));
+    }
+
+    public function testAsyncWrongInitialDelay()
+    {
+        $this->expectException(MindeeApiException::class);
+        $asyncParseOptions = new EnqueueAndParseMethodOptions();
+        $asyncParseOptions->setInitialDelaySec(0);
+    }
+
+    public function testAsyncWrongPollingDelay()
+    {
+        $this->expectException(MindeeApiException::class);
+        $asyncParseOptions = new EnqueueAndParseMethodOptions();
+        $asyncParseOptions->setDelaySec(0);
+    }
+}

--- a/tests/Error/MindeeHttpExceptionTest.php
+++ b/tests/Error/MindeeHttpExceptionTest.php
@@ -1,0 +1,114 @@
+<?php
+
+namespace Error;
+
+use Mindee\Client;
+use Mindee\Error\MindeeHttpClientException;
+use Mindee\Error\MindeeHttpException;
+use Mindee\Input\PathInput;
+use Mindee\Product\Invoice\InvoiceV4;
+use PHPUnit\Framework\TestCase;
+
+class MindeeHttpExceptionTest extends TestCase
+{
+    private string $errorDir;
+    private PathInput $dummyFile;
+    private Client $dummyClient;
+
+    protected function setUp(): void
+    {
+        $this->errorDir = (getenv('GITHUB_WORKSPACE') ?: ".") . "/tests/resources/errors/";
+        $this->dummyClient = new Client("dummy-key");
+        $this->dummyFile = $this->dummyClient->sourceFromPath(
+            (getenv('GITHUB_WORKSPACE') ?: ".") . "/tests/resources/file_types/pdf/blank.pdf"
+        );
+    }
+
+    public function testHTTPClientErrorShouldRaise()
+    {
+        $this->expectException(MindeeHttpClientException::class);
+        $this->dummyClient->parse(InvoiceV4::class, $this->dummyFile);
+    }
+
+    public function testHTTPEnqueueClientException()
+    {
+        $this->expectException(MindeeHttpClientException::class);
+        $this->dummyClient->enqueue(InvoiceV4::class, $this->dummyFile);
+    }
+
+    public function testHTTPParseClientException()
+    {
+        $this->expectException(MindeeHttpClientException::class);
+        $this->dummyClient->enqueue(InvoiceV4::class, $this->dummyFile);
+    }
+
+    public function testHTTPEnqueueAndParseClientException()
+    {
+        $this->expectException(MindeeHttpClientException::class);
+        $this->dummyClient->enqueueAndParse(InvoiceV4::class, $this->dummyFile);
+    }
+
+    public function testHTTP400Exception()
+    {
+        $json = file_get_contents($this->errorDir . "error_400_no_details.json");
+        $errorObj = json_decode($json, true);
+        $error400 = MindeeHttpException::handleError("dummy-url", $errorObj, 400);
+        $this->assertEquals(400, $error400->statusCode);
+        $this->assertEquals("SomeCode", $error400->apiCode);
+        $this->assertEquals("Some scary message here", $error400->apiMessage);
+        $this->assertNull($error400->apiDetails);
+        $this->expectException(MindeeHttpClientException::class);
+        throw $error400;
+    }
+
+    public function testHTTP401Exception()
+    {
+        $json = file_get_contents($this->errorDir . "error_401_invalid_token.json");
+        $errorObj = json_decode($json, true);
+        $error401 = MindeeHttpException::handleError("dummy-url", $errorObj, 401);
+        $this->assertEquals(401, $error401->statusCode);
+        $this->assertEquals("Unauthorized", $error401->apiCode);
+        $this->assertEquals("Authorization required", $error401->apiMessage);
+        $this->assertEquals("Invalid token provided", $error401->apiDetails);
+        $this->expectException(MindeeHttpClientException::class);
+        throw $error401;
+    }
+
+    public function testHTTP429Exception()
+    {
+        $json = file_get_contents($this->errorDir . "error_429_too_many_requests.json");
+        $errorObj = json_decode($json, true);
+        $error429 = MindeeHttpException::handleError("dummy-url", $errorObj, 429);
+        $this->assertEquals(429, $error429->statusCode);
+        $this->assertEquals("TooManyRequests", $error429->apiCode);
+        $this->assertEquals("Too many requests", $error429->apiMessage);
+        $this->assertEquals("Too Many Requests.", $error429->apiDetails);
+        $this->expectException(MindeeHttpClientException::class);
+        throw $error429;
+    }
+
+    public function testHTTP500Exception()
+    {
+        $json = file_get_contents($this->errorDir . "error_500_inference_fail.json");
+        $errorObj = json_decode($json, true);
+        $error500 = MindeeHttpException::handleError("dummy-url", $errorObj, 500);
+        $this->assertEquals(500, $error500->statusCode);
+        $this->assertEquals("failure", $error500->apiCode);
+        $this->assertEquals("Inference failed", $error500->apiMessage);
+        $this->assertEquals("Can not run prediction: ", $error500->apiDetails);
+        $this->expectException(MindeeHttpClientException::class);
+        throw $error500;
+    }
+
+    public function testHTTP500HTMLError()
+    {
+        $errorRefContents = file_get_contents($this->errorDir . "error_50x.html");
+        $error500 = MindeeHttpException::handleError("dummy-url", $errorRefContents, 500);
+        $this->assertEquals(500, $error500->statusCode);
+        $this->assertEquals("UnknownError", $error500->apiCode);
+        $this->assertEquals("Server sent back an unexpected reply.", $error500->apiMessage);
+        $this->assertEquals($errorRefContents, $error500->apiDetails);
+        $this->expectException(MindeeHttpClientException::class);
+        throw $error500;
+    }
+}

--- a/tests/Geometry/BBoxTest.php
+++ b/tests/Geometry/BBoxTest.php
@@ -1,0 +1,73 @@
+<?php
+
+namespace Geometry;
+
+use Mindee\Geometry\BBox;
+use Mindee\Geometry\BBoxUtils;
+use Mindee\Geometry\Point;
+use Mindee\Geometry\Polygon;
+use PHPUnit\Framework\TestCase;
+
+class BBoxTest extends TestCase
+{
+    public function testWith0PolygonMustGetNull()
+    {
+        $polygon = new Polygon();
+        $bbox = BBoxUtils::generateBBoxFromPolygon($polygon);
+        $this->assertNull($bbox);
+    }
+
+    public function testWith1PolygonAndANullPolygonMustGetPolygon()
+    {
+        $polygons = [];
+        $polygons[] = new Polygon(
+            [new Point(0.081, 0.442), new Point(0.15, 0.442), new Point(0.15, 0.451), new Point(0.081, 0.451)]
+        );
+        $polygons[] = null;
+        $bbox = BBoxUtils::generateBBoxFromPolygons($polygons);
+
+        $this->assertEquals(0.442, $bbox->getMinY());
+        $this->assertEquals(0.081, $bbox->getMinX());
+        $this->assertEquals(0.451, $bbox->getMaxY());
+        $this->assertEquals(0.15, $bbox->getMaxX());
+    }
+
+    public function testWithOnePolygonMustGetValidBBox()
+    {
+        $polygon = new Polygon(
+            [new Point(0.081, 0.442), new Point(0.15, 0.442), new Point(0.15, 0.451), new Point(0.081, 0.451)]
+        );
+        $bbox = BBoxUtils::generateBBoxFromPolygon($polygon);
+        $this->assertEquals(0.442, $bbox->getMinY());
+        $this->assertEquals(0.081, $bbox->getMinX());
+        $this->assertEquals(0.451, $bbox->getMaxY());
+        $this->assertEquals(0.15, $bbox->getMaxX());
+    }
+
+    public function testWithTwoPolygonsMustGetValidBBox()
+    {
+        $polygon1 = new Polygon(
+            [new Point(0.081, 0.442), new Point(0.15, 0.442), new Point(0.15, 0.451), new Point(0.081, 0.451)]
+        );
+        $polygon2 = new Polygon(
+            [new Point(0.157, 0.442), new Point(0.26, 0.442), new Point(0.26, 0.451), new Point(0.157, 0.451)]
+        );
+        $polygons = [$polygon1, $polygon2];
+        $bbox = BBoxUtils::generateBBoxFromPolygons($polygons);
+        $this->assertEquals(0.442, $bbox->getMinY());
+        $this->assertEquals(0.081, $bbox->getMinX());
+        $this->assertEquals(0.451, $bbox->getMaxY());
+        $this->assertEquals(0.26, $bbox->getMaxX());
+    }
+
+    public function testMerge2BboxMustGetValidBBox()
+    {
+        $bbox1 = new BBox(0.081, 0.15, 0.442, 0.451);
+        $bbox2 = new BBox(0.157, 0.26, 0.442, 0.451);
+        $mergedBBoxes = BBoxUtils::mergeBBoxes([$bbox1, $bbox2]);
+        $this->assertEquals(0.442, $mergedBBoxes->getMinY());
+        $this->assertEquals(0.081, $mergedBBoxes->getMinX());
+        $this->assertEquals(0.451, $mergedBBoxes->getMaxY());
+        $this->assertEquals(0.26, $mergedBBoxes->getMaxX());
+    }
+}

--- a/tests/Geometry/PolygonUtilsTest.php
+++ b/tests/Geometry/PolygonUtilsTest.php
@@ -1,0 +1,82 @@
+<?php
+
+namespace Geometry;
+
+use Mindee\Error\MindeeGeometryException;
+use Mindee\Geometry\Point;
+use Mindee\Geometry\Polygon;
+use Mindee\Geometry\PolygonUtils;
+use PHPUnit\Framework\TestCase;
+
+class PolygonUtilsTest extends TestCase
+{
+    private Polygon $polygonWhichIsNotRectangle;
+    private Polygon $polygon1;
+    private Polygon $polygon2;
+
+    public function __construct(?string $name = null, array $data = [], $dataName = '')
+    {
+        parent::__construct($name, $data, $dataName);
+        $this->polygonWhichIsNotRectangle = new Polygon(
+            [new Point(0.123, 0.53), new Point(0.175, 0.53), new Point(0.175, 0.546), new Point(0.123, 0.546)]
+        );
+
+        $this->polygon1 = new Polygon(
+            [new Point(0.081, 0.442), new Point(0.15, 0.442), new Point(0.15, 0.451), new Point(0.081, 0.451)]
+        );
+        $this->polygon2 = new Polygon(
+            [new Point(0.157, 0.442), new Point(0.26, 0.442), new Point(0.26, 0.451), new Point(0.157, 0.451)]
+        );
+    }
+
+    public function testGivenAValidPolygonMustGetTheValidCentroid()
+    {
+        $this->assertEquals($this->polygonWhichIsNotRectangle->getCentroid(), new Point(0.149, 0.538));
+    }
+
+    public function testGivenAValidPolygonMustGetTheMinX()
+    {
+        $this->assertEquals(0.123, PolygonUtils::getMinXCoordinate($this->polygonWhichIsNotRectangle));
+    }
+
+    public function testGivenAValidPolygonMustGetTheMinY()
+    {
+        $this->assertEquals(0.53, PolygonUtils::getMinYCoordinate($this->polygonWhichIsNotRectangle));
+    }
+
+    public function testGivenAValidPolygonMustGetTheMaxX()
+    {
+        $this->assertEquals(0.175, PolygonUtils::getMaxXCoordinate($this->polygonWhichIsNotRectangle));
+    }
+
+    public function testGivenAValidPolygonMustGetTheMaxY()
+    {
+        $this->assertEquals(0.546, PolygonUtils::getMaxYCoordinate($this->polygonWhichIsNotRectangle));
+    }
+
+    public function testMergePolygonsWithTwoNotNullMustGetAValidPolygon()
+    {
+        $mergedPolygon = PolygonUtils::merge($this->polygon1, $this->polygon2);
+
+        $this->assertEquals(0.442, PolygonUtils::getMinYCoordinate($mergedPolygon));
+        $this->assertEquals(0.081, PolygonUtils::getMinXCoordinate($mergedPolygon));
+        $this->assertEquals(0.451, PolygonUtils::getMaxYCoordinate($mergedPolygon));
+        $this->assertEquals(0.26, PolygonUtils::getMaxXCoordinate($mergedPolygon));
+    }
+
+    public function testMergeWithNullPolygonMustThrow()
+    {
+        $this->expectException(MindeeGeometryException::class);
+        PolygonUtils::merge(null, null);
+    }
+
+    public function testMergeWith1PolygonAndANullPolygonMustGetPolygon()
+    {
+        $mergedPolygon = PolygonUtils::merge($this->polygon1, null);
+
+        $this->assertEquals(0.442, PolygonUtils::getMinYCoordinate($mergedPolygon));
+        $this->assertEquals(0.081, PolygonUtils::getMinXCoordinate($mergedPolygon));
+        $this->assertEquals(0.451, PolygonUtils::getMaxYCoordinate($mergedPolygon));
+        $this->assertEquals(0.15, PolygonUtils::getMaxXCoordinate($mergedPolygon));
+    }
+}

--- a/tests/Http/MindeeApiTest.php
+++ b/tests/Http/MindeeApiTest.php
@@ -33,6 +33,6 @@ class MindeeApiTest extends TestCase
     {
         $this->expectException(MindeeException::class);
         putenv(API_KEY_ENV_NAME . '=');
-        $settings = new MindeeApi(null, InvoiceSplitterV1::$endpointName);
+        new MindeeApi(null, InvoiceSplitterV1::$endpointName);
     }
 }

--- a/tests/Http/MindeeApiTest.php
+++ b/tests/Http/MindeeApiTest.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace Http;
+
+use Mindee\Error\MindeeException;
+use Mindee\Http\MindeeApi;
+use Mindee\Product\InvoiceSplitter\InvoiceSplitterV1;
+use PHPUnit\Framework\TestCase;
+
+use const Mindee\Http\API_KEY_ENV_NAME;
+
+class MindeeApiTest extends TestCase
+{
+    public function testGivenOTSParametersAProperMindeeApiObjectShouldBeCreated()
+    {
+        $settings = new MindeeApi("my-api-key", InvoiceSplitterV1::$endpointName);
+        $this->assertEquals("my-api-key", $settings->apiKey);
+        $this->assertEquals(InvoiceSplitterV1::$endpointName, $settings->endpointName);
+        $this->assertEquals(\Mindee\Client::DEFAULT_OWNER, $settings->accountName);
+        $this->assertEquals("1", $settings->version);
+    }
+
+    public function testGivenCustomParametersAProperMindeeApiObjectShouldBeCreated()
+    {
+        $settings = new MindeeApi("my-api-key", "custom-endpoint-name", "custom-owner-name", "1.3");
+        $this->assertEquals("my-api-key", $settings->apiKey);
+        $this->assertEquals("custom-endpoint-name", $settings->endpointName);
+        $this->assertEquals("custom-owner-name", $settings->accountName);
+        $this->assertEquals("1.3", $settings->version);
+    }
+
+    public function testGivenInvalidApiKeyAnExceptionShouldBeThrown()
+    {
+        $this->expectException(MindeeException::class);
+        putenv(API_KEY_ENV_NAME . '=');
+        $settings = new MindeeApi(null, InvoiceSplitterV1::$endpointName);
+    }
+}

--- a/tests/Input/LocalInputSourceTest.php
+++ b/tests/Input/LocalInputSourceTest.php
@@ -1,0 +1,101 @@
+<?php
+
+namespace Input;
+
+use Mindee\Client;
+use Mindee\Error\MindeeSourceException;
+use Mindee\Input\InputSource;
+use Mindee\Input\PathInput;
+use Mindee\Input\URLInputSource;
+use PHPUnit\Framework\TestCase;
+
+use const Mindee\Input\KEEP_ONLY;
+
+class LocalInputSourceTest extends TestCase
+{
+    protected Client $dummyClient;
+    protected string $fileTypesDir;
+
+    public function setUp(): void
+    {
+        $this->dummyClient = new Client("dummy-key");
+        putenv('MINDEE_API_KEY' . '=');
+        $this->fileTypesDir = (
+            getenv('GITHUB_WORKSPACE') ?: "."
+            ) . "/tests/resources/file_types/";
+    }
+
+//    public function testPDFReconstructOK()
+//    {
+//        $inputObj = new PathInput($this->fileTypesDir . "pdf/multipage.pdf");
+//        $inputObj->processPDF(KEEP_ONLY, 2, [0, 1, 2, 3, 4]); // TODO: processPDF feature
+//        $this->assertInstanceOf(resource, $inputObj->readContents()); TODO: find proper type for this
+//    }
+
+    public function testPDFReadContents()
+    {
+        $inputDoc = new PathInput($this->fileTypesDir . "/pdf/multipage.pdf");
+        $contents = $inputDoc->readContents(false);
+        $this->assertEquals("multipage.pdf", $contents[0]);
+    }
+
+//    public function testPDFreconstructNoCut(){ // TODO when pdf handling lib is added
+//
+//    }
+
+//    public function testPDFCutNPages(){ // TODO when pdf handling lib is added
+//
+//    }
+
+//    public function testPDFKeep5FirstPages(){ // TODO when pdf handling lib is added
+//
+//    }
+
+//    public function testPDFKeepInvalidPages(){ // TODO when pdf handling lib is added
+//
+//    }
+
+//    public function testPDFRemove5LastPages(){ // TODO when pdf handling lib is added
+//
+//    }
+
+//    public function testPDFRemove5FirstPages(){ // TODO when pdf handling lib is added
+//
+//    }
+
+//    public function testPDFRemoveInvalidPages(){ // TODO when pdf handling lib is added
+//
+//    }
+
+//    public function testPDFKeepNoPages(){ // TODO when pdf handling lib is added
+//
+//    }
+
+//    public function testPDFRemoveAllPages(){ // TODO when pdf handling lib is added
+//
+//    }
+
+//    public function testPDFInputFromFile(){ // TODO when pdf handling lib is added
+//
+//    }
+
+//    public function testPDFInputFromBase64(){ // TODO when pdf handling lib is added
+//
+//    }
+
+//    public function testPDFInputFromBytes(){ // TODO when pdf handling lib is added
+//
+//    }
+
+    public function testInputFromHTTPShouldThrow()
+    {
+        $this->expectException(MindeeSourceException::class);
+        $this->dummyClient->sourceFromUrl("http://example.com/invoice.pdf");
+    }
+
+    public function testInputFromHTTPShouldNotThrow()
+    {
+        $inputDoc = $this->dummyClient->sourceFromUrl("https://example.com/invoice.pdf");
+        $this->assertInstanceOf(URLInputSource::class, $inputDoc);
+    }
+}

--- a/tests/Parsing/Common/AsyncPredictResponseTest.php
+++ b/tests/Parsing/Common/AsyncPredictResponseTest.php
@@ -1,0 +1,95 @@
+<?php
+
+namespace Parsing\Common;
+
+use Mindee\Input\PathInput;
+use Mindee\Parsing\Common\AsyncPredictResponse;
+use Mindee\Product\InvoiceSplitter\InvoiceSplitterV1;
+use PHPUnit\Framework\TestCase;
+
+const ASYNC_DIR = "./tests/resources/async";
+
+const FILE_PATH_POST_SUCCESS = ASYNC_DIR . "/post_success.json";
+const FILE_PATH_POST_FAIL = ASYNC_DIR . "/post_fail_forbidden.json";
+const FILE_PATH_GET_PROCESSING = ASYNC_DIR . "/get_processing.json";
+const FILE_PATH_GET_COMPLETED = ASYNC_DIR . "/get_completed.json";
+
+
+class AsyncPredictResponseTest extends TestCase
+{
+    public PathInput $fileInput;
+
+    public function __construct(?string $name = null, array $data = [], $dataName = '')
+    {
+        parent::__construct($name, $data, $dataName);
+        $this->fileInput = new PathInput("./tests/resources/products/invoice_splitter/default_sample.pdf");
+    }
+
+    public function testAsyncResponsePOSTSuccess()
+    {
+        $json = file_get_contents(FILE_PATH_POST_SUCCESS);
+        $response = json_decode($json, true);
+        $parsedResponse = new AsyncPredictResponse(InvoiceSplitterV1::class, $response);
+        $this->assertNotNull($parsedResponse->job);
+        $this->assertEquals(
+            "2023-02-16T12:33:49.602947+00:00",
+            $parsedResponse->job->issuedAt->format('Y-m-d\TH:i:s.uP')
+        );
+        $this->assertNull($parsedResponse->job->availableAt);
+        $this->assertEquals("waiting", $parsedResponse->job->status);
+        $this->assertEquals("76c90710-3a1b-4b91-8a39-31a6543e347c", $parsedResponse->job->id);
+        $this->assertEmpty($parsedResponse->apiRequest->error);
+    }
+
+    public function testAsyncResponsePOSTFail()
+    {
+        $json = file_get_contents(FILE_PATH_POST_FAIL);
+        $response = json_decode($json, true);
+        $parsedResponse = new AsyncPredictResponse(InvoiceSplitterV1::class, $response);
+        $this->assertNotNull($parsedResponse->job);
+        $this->assertEquals(
+            "2023-01-01T00:00:00+00:00",
+            $parsedResponse->job->issuedAt->format('Y-m-d\TH:i:sP')
+        );
+        $this->assertNull($parsedResponse->job->availableAt);
+        $this->assertNull($parsedResponse->job->status);
+        $this->assertNull($parsedResponse->job->id);
+        $this->assertNull($parsedResponse->job->id);
+        $this->assertEquals("Forbidden", $parsedResponse->apiRequest->error["code"]);
+    }
+
+    public function testAsyncResponseGETProcessing()
+    {
+        $json = file_get_contents(FILE_PATH_GET_PROCESSING);
+        $response = json_decode($json, true);
+        $parsedResponse = new AsyncPredictResponse(InvoiceSplitterV1::class, $response);
+        $this->assertNotNull($parsedResponse->job);
+        $this->assertEquals(
+            "2023-03-16T12:33:49.602947",
+            $parsedResponse->job->issuedAt->format('Y-m-d\TH:i:s.u')
+        );
+        $this->assertNull($parsedResponse->job->availableAt);
+        $this->assertEquals("processing", $parsedResponse->job->status);
+        $this->assertEquals("76c90710-3a1b-4b91-8a39-31a6543e347c", $parsedResponse->job->id);
+        $this->assertEmpty($parsedResponse->apiRequest->error);
+    }
+
+    public function testAsyncResponseGETCompleted()
+    {
+        $json = file_get_contents(FILE_PATH_GET_COMPLETED);
+        $response = json_decode($json, true);
+        $parsedResponse = new AsyncPredictResponse(InvoiceSplitterV1::class, $response);
+        $this->assertNotNull($parsedResponse->job);
+        $this->assertEquals(
+            "2023-03-21T13:52:56.326107",
+            $parsedResponse->job->issuedAt->format('Y-m-d\TH:i:s.u')
+        );
+        $this->assertEquals(
+            "2023-03-21T13:53:00.990339",
+            $parsedResponse->job->availableAt->format('Y-m-d\TH:i:s.u')
+        );
+        $this->assertEquals("completed", $parsedResponse->job->status);
+        $this->assertEquals("b6caf9e8-9bcc-4412-bcb7-f5b416678f0d", $parsedResponse->job->id);
+        $this->assertEmpty($parsedResponse->apiRequest->error);
+    }
+}

--- a/tests/Parsing/Common/AsyncPredictResponseTest.php
+++ b/tests/Parsing/Common/AsyncPredictResponseTest.php
@@ -2,32 +2,29 @@
 
 namespace Parsing\Common;
 
-use Mindee\Input\PathInput;
 use Mindee\Parsing\Common\AsyncPredictResponse;
 use Mindee\Product\InvoiceSplitter\InvoiceSplitterV1;
 use PHPUnit\Framework\TestCase;
 
-const ASYNC_DIR = "./tests/resources/async";
-
-const FILE_PATH_POST_SUCCESS = ASYNC_DIR . "/post_success.json";
-const FILE_PATH_POST_FAIL = ASYNC_DIR . "/post_fail_forbidden.json";
-const FILE_PATH_GET_PROCESSING = ASYNC_DIR . "/get_processing.json";
-const FILE_PATH_GET_COMPLETED = ASYNC_DIR . "/get_completed.json";
-
-
 class AsyncPredictResponseTest extends TestCase
 {
-    public PathInput $fileInput;
+    private string $filePathPostSuccess;
+    private string $filePathPostFail;
+    private string $filePathGetProcessing;
+    private string $filePathGetCompleted;
 
-    public function __construct(?string $name = null, array $data = [], $dataName = '')
+    protected function setUp(): void
     {
-        parent::__construct($name, $data, $dataName);
-        $this->fileInput = new PathInput("./tests/resources/products/invoice_splitter/default_sample.pdf");
+        $asyncDir = (getenv('GITHUB_WORKSPACE') ?: ".") . "/tests/resources/async";
+        $this->filePathPostSuccess = $asyncDir . "/post_success.json";
+        $this->filePathPostFail = $asyncDir . "/post_fail_forbidden.json";
+        $this->filePathGetProcessing = $asyncDir . "/get_processing.json";
+        $this->filePathGetCompleted = $asyncDir . "/get_completed.json";
     }
 
     public function testAsyncResponsePOSTSuccess()
     {
-        $json = file_get_contents(FILE_PATH_POST_SUCCESS);
+        $json = file_get_contents($this->filePathPostSuccess);
         $response = json_decode($json, true);
         $parsedResponse = new AsyncPredictResponse(InvoiceSplitterV1::class, $response);
         $this->assertNotNull($parsedResponse->job);
@@ -43,7 +40,7 @@ class AsyncPredictResponseTest extends TestCase
 
     public function testAsyncResponsePOSTFail()
     {
-        $json = file_get_contents(FILE_PATH_POST_FAIL);
+        $json = file_get_contents($this->filePathPostFail);
         $response = json_decode($json, true);
         $parsedResponse = new AsyncPredictResponse(InvoiceSplitterV1::class, $response);
         $this->assertNotNull($parsedResponse->job);
@@ -60,7 +57,7 @@ class AsyncPredictResponseTest extends TestCase
 
     public function testAsyncResponseGETProcessing()
     {
-        $json = file_get_contents(FILE_PATH_GET_PROCESSING);
+        $json = file_get_contents($this->filePathGetProcessing);
         $response = json_decode($json, true);
         $parsedResponse = new AsyncPredictResponse(InvoiceSplitterV1::class, $response);
         $this->assertNotNull($parsedResponse->job);
@@ -76,7 +73,7 @@ class AsyncPredictResponseTest extends TestCase
 
     public function testAsyncResponseGETCompleted()
     {
-        $json = file_get_contents(FILE_PATH_GET_COMPLETED);
+        $json = file_get_contents($this->filePathGetCompleted);
         $response = json_decode($json, true);
         $parsedResponse = new AsyncPredictResponse(InvoiceSplitterV1::class, $response);
         $this->assertNotNull($parsedResponse->job);

--- a/tests/Parsing/Common/Extras/CropperExtraTest.php
+++ b/tests/Parsing/Common/Extras/CropperExtraTest.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace Parsing\Common\Extras;
+
+use Mindee\Parsing\Common\Extras\CropperExtra;
+use PHPUnit\Framework\TestCase;
+
+class CropperExtraTest extends TestCase //TODO: complete when receipt is implemented.
+{
+    public function testPlaceHolderForCI()
+    {
+        $this->assertTrue(true);
+    }
+}

--- a/tests/Parsing/Common/Ocr/OcrTest.php
+++ b/tests/Parsing/Common/Ocr/OcrTest.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace Parsing\Common\Ocr;
+
+use Mindee\Parsing\Common\Ocr\Ocr;
+use PHPUnit\Framework\TestCase;
+
+class OcrTest extends TestCase
+{
+    public function testResponse()
+    {
+        $json = file_get_contents(
+            (
+                getenv('GITHUB_WORKSPACE') ?: "."
+            ) . "/tests/resources/extras/ocr/complete.json"
+        );
+        $jsonData = json_decode($json, true);
+        $expectedText = file_get_contents(
+            (
+                getenv('GITHUB_WORKSPACE') ?: "."
+            ) . "/tests/resources/extras/ocr/ocr.txt"
+        );
+        $ocr = new Ocr($jsonData["document"]["ocr"]);
+        $this->assertEquals($expectedText, strval($ocr));
+        $this->assertEquals($expectedText, strval($ocr->mvisionV1->pages[0]));
+    }
+}

--- a/tests/Parsing/Common/PredictResponseTest.php
+++ b/tests/Parsing/Common/PredictResponseTest.php
@@ -11,7 +11,10 @@ class PredictResponseTest extends TestCase
 {
     public function testLoadingFromJSONShouldCreateAPredictResponse()
     {
-        $json = file_get_contents("./tests/resources/products/invoices/response_v4/complete.json");
+        $json = file_get_contents(
+            (getenv('GITHUB_WORKSPACE') ?: "."
+            ) . "/tests/resources/products/invoices/response_v4/complete.json"
+        );
         $response = json_decode($json, true);
         $parsedResponse = new PredictResponse(InvoiceV4::class, $response);
         $this->assertInstanceOf(InvoiceV4::class, $parsedResponse->document->inference);

--- a/tests/Parsing/Common/PredictResponseTest.php
+++ b/tests/Parsing/Common/PredictResponseTest.php
@@ -12,7 +12,8 @@ class PredictResponseTest extends TestCase
     public function testLoadingFromJSONShouldCreateAPredictResponse()
     {
         $json = file_get_contents(
-            (getenv('GITHUB_WORKSPACE') ?: "."
+            (
+                getenv('GITHUB_WORKSPACE') ?: "."
             ) . "/tests/resources/products/invoices/response_v4/complete.json"
         );
         $response = json_decode($json, true);

--- a/tests/Parsing/Common/PredictResponseTest.php
+++ b/tests/Parsing/Common/PredictResponseTest.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Parsing\Common;
+
+use Mindee\Parsing\Common\PredictResponse;
+use Mindee\Product\Invoice\InvoiceV4;
+use Mindee\Product\Invoice\InvoiceV4Document;
+use PHPUnit\Framework\TestCase;
+
+class PredictResponseTest extends TestCase
+{
+    public function testLoadingFromJSONShouldCreateAPredictResponse()
+    {
+        $json = file_get_contents("./tests/resources/products/invoices/response_v4/complete.json");
+        $response = json_decode($json, true);
+        $parsedResponse = new PredictResponse(InvoiceV4::class, $response);
+        $this->assertInstanceOf(InvoiceV4::class, $parsedResponse->document->inference);
+        foreach ($parsedResponse->document->inference->pages as $page) {
+            $this->assertInstanceOf(InvoiceV4Document::class, $page->prediction);
+        }
+        $this->assertEquals(2, $parsedResponse->document->nPages);
+    }
+}

--- a/tests/Parsing/Standard/AmountFieldTest.php
+++ b/tests/Parsing/Standard/AmountFieldTest.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace Parsing\Standard;
+
+use Mindee\Parsing\Standard\AmountField;
+use PHPUnit\Framework\TestCase;
+
+class AmountFieldTest extends TestCase
+{
+    public function testConstructor()
+    {
+        $fieldArray = [
+            "value" => "2",
+            "confidence" => 0.1,
+            "polygon" => [
+                [0.016, 0.707],
+                [0.414, 0.707],
+                [0.414, 0.831],
+                [0.016, 0.831],
+            ]
+        ];
+        $amount = new AmountField($fieldArray);
+        $this->assertEquals(2, $amount->value);
+    }
+
+    public function testConstructorNoAmount()
+    {
+        $fieldArray = [
+            "value" => "N/A",
+            "confidence" => 0.1
+        ];
+        $amount = new AmountField($fieldArray);
+        $this->assertNull($amount->value);
+    }
+}

--- a/tests/Parsing/Standard/ClassificationFieldTest.php
+++ b/tests/Parsing/Standard/ClassificationFieldTest.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace Parsing\Standard;
+
+use Mindee\Parsing\Standard\ClassificationField;
+use PHPUnit\Framework\TestCase;
+
+class ClassificationFieldTest extends TestCase
+{
+    public function testConstructor()
+    {
+        $fieldArray = [
+            "value" => "automobile",
+            "confidence" => 0.1
+        ];
+        $classification = new ClassificationField($fieldArray);
+        $this->assertEquals("automobile", $classification->value);
+        $this->assertEquals(0.1, $classification->confidence);
+    }
+
+    public function testConstructorNoClassificatio()
+    {
+        $fieldArray = [
+            "value" => "N/A",
+            "confidence" => 0.1
+        ];
+        $classification = new ClassificationField($fieldArray);
+        $this->assertNull($classification->value);
+    }
+}

--- a/tests/Parsing/Standard/CompanyRegistrationFieldTest.php
+++ b/tests/Parsing/Standard/CompanyRegistrationFieldTest.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace Parsing\Standard;
+
+use Mindee\Parsing\Standard\CompanyRegistrationField;
+use PHPUnit\Framework\TestCase;
+
+class CompanyRegistrationFieldTest extends TestCase
+{
+    public function testConstructor()
+    {
+        $fieldArray = [
+            [
+                "confidence" => 1.0,
+                "polygon" => [
+                    [346, 0.199],
+                    [0.484, 0.199],
+                    [0.484, 0.217],
+                    [0.346, 0.21]
+                ]
+            ],
+            "type" => "VAT NUMBER",
+            "value" => "FR00000000000"
+        ];
+
+        $companyRegistration = new CompanyRegistrationField($fieldArray);
+        $this->assertEquals("FR00000000000", $companyRegistration->value);
+        $this->assertEquals("VAT NUMBER", $companyRegistration->type);
+    }
+}

--- a/tests/Parsing/Standard/DateFieldTest.php
+++ b/tests/Parsing/Standard/DateFieldTest.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace Parsing\Standard;
+
+use Mindee\Parsing\Standard\DateField;
+use PHPUnit\Framework\TestCase;
+
+class DateFieldTest extends TestCase
+{
+    public function testConstructor()
+    {
+        $fieldArray = [
+            "value" => "2018-04-01",
+            "confidence" => 0.1,
+            "polygon" => [
+                [0.016, 0.707],
+                [0.414, 0.707],
+                [0.414, 0.831],
+                [0.016, 0.831],
+            ]
+        ];
+        $date = new DateField($fieldArray);
+        $this->assertEquals("2018-04-01", $date->value);
+        $this->assertInstanceOf(\DateTimeImmutable::class, $date->dateObject);
+    }
+
+    public function testConstructorNoDate()
+    {
+        $fieldArray = [
+            "iso" => "N/A",
+            "confidence" => 0.1
+        ];
+        $date = new DateField($fieldArray);
+        $this->assertNull($date->value);
+    }
+}

--- a/tests/Parsing/Standard/LocaleFieldTest.php
+++ b/tests/Parsing/Standard/LocaleFieldTest.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace Parsing\Standard;
+
+use Mindee\Parsing\Standard\LocaleField;
+use PHPUnit\Framework\TestCase;
+
+class LocaleFieldTest extends TestCase
+{
+    public function testConstructor()
+    {
+        $fieldArray = [
+            "confidence" => 0.82,
+            "country" => "GB",
+            "currency" => "GBP",
+            "language" => "en",
+            "value" => "en-GB",
+        ];
+
+        $companyRegistration = new LocaleField($fieldArray);
+        $this->assertEquals("en-GB", $companyRegistration->value);
+        $this->assertEquals("en", $companyRegistration->language);
+        $this->assertEquals("GB", $companyRegistration->country);
+        $this->assertEquals("GBP", $companyRegistration->currency);
+    }
+
+    public function testConstructorNoValues()
+    {
+        $fieldArray = [
+            "confidence" => 0,
+            "country" => null,
+            "currency" => null,
+            "language" => null,
+            "value" => null,
+        ];
+        $classification = new LocaleField($fieldArray);
+        $this->assertNull($classification->value);
+        $this->assertNull($classification->language);
+        $this->assertNull($classification->country);
+        $this->assertNull($classification->currency);
+    }
+}

--- a/tests/Parsing/Standard/PaymentDetailsFieldTest.php
+++ b/tests/Parsing/Standard/PaymentDetailsFieldTest.php
@@ -1,0 +1,60 @@
+<?php
+
+namespace Parsing\Standard;
+
+use Mindee\Parsing\Standard\PaymentDetailsField;
+use PHPUnit\Framework\TestCase;
+
+class PaymentDetailsFieldTest extends TestCase
+{
+    public function testConstructor()
+    {
+        $fieldArray = [
+            "account_number" => "12345678910",
+            "confidence" => 0.94,
+            "iban" => "FR7640254025476501124705368",
+            "routing_number" => "211212121212",
+            "swift" => "CEPAFRPP",
+            "polygon" => [
+                [
+                    0.666,
+                    0.123
+                ],
+                [
+                    0.861,
+                    0.123
+                ],
+                [
+                    0.861,
+                    0.14
+                ],
+                [
+                    0.666,
+                    0.14
+                ]
+            ],
+        ];
+
+        $companyRegistration = new PaymentDetailsField($fieldArray);
+        $this->assertEquals("FR7640254025476501124705368", $companyRegistration->iban);
+        $this->assertEquals("211212121212", $companyRegistration->routingNumber);
+        $this->assertEquals("CEPAFRPP", $companyRegistration->swift);
+        $this->assertEquals("12345678910", $companyRegistration->accountNumber);
+    }
+
+    public function testConstructorNoValues()
+    {
+        $fieldArray = [
+            "confidence" => 0,
+            "iban" => null,
+            "routing_number" => null,
+            "swift" => null,
+            "account_number" => null,
+        ];
+        $companyRegistration = new PaymentDetailsField($fieldArray);
+        $this->assertNull($companyRegistration->iban);
+        $this->assertNull($companyRegistration->routingNumber);
+        $this->assertNull($companyRegistration->swift);
+        $this->assertNull($companyRegistration->accountNumber);
+    }
+}

--- a/tests/Parsing/Standard/PositionFieldTest.php
+++ b/tests/Parsing/Standard/PositionFieldTest.php
@@ -1,0 +1,48 @@
+<?php
+
+namespace Parsing\Standard;
+
+use Mindee\Parsing\Standard\PositionField;
+use PHPUnit\Framework\TestCase;
+
+class PositionFieldTest extends TestCase
+{
+    public function testConstructor()
+    {
+        $fieldArray = [
+            "bounding_box" => [
+                [0.016, 0.707],
+                [0.414, 0.707],
+                [0.414, 0.831],
+                [0.016, 0.831]
+            ],
+            "confidence" => 0.1,
+            "quadrangle" => [[0.016, 0.707], [0.414, 0.707], [0.414, 0.831], [0.016, 0.831]],
+            "polygon" => [[0.016, 0.707], [0.414, 0.707], [0.414, 0.831], [0.016, 0.831]],
+            "rectangle" => [[0.016, 0.707], [0.414, 0.707], [0.414, 0.831], [0.016, 0.831]]
+        ];
+
+        $field = new PositionField($fieldArray);
+        $this->assertEquals(4, count($field->value->getCoordinates()));
+        $this->assertEquals(0.1, $field->confidence);
+        $this->assertEquals(0.016, $field->polygon->getCoordinates()[0]->getX());
+    }
+
+    public function testConstructorFail()
+    {
+        $fieldArray = [
+            "bounding_box" => [
+                [0.016, 0.707],
+                [0.414, 0.707],
+                [0.414, 0.831],
+                [0.016, 0.831]
+            ],
+            "confidence" => 0.1,
+            "quadrangle" => [[0.016, 0.707], [0.414, 0.707], [0.414, 0.831], [0.016, 0.831]],
+            "rectangle" => [[0.016, 0.707], [0.414, 0.707], [0.414, 0.831], [0.016, 0.831]]
+        ];
+
+        $field = new PositionField($fieldArray);
+        $this->assertNull($field->value);
+    }
+}

--- a/tests/Parsing/Standard/StringFieldTest.php
+++ b/tests/Parsing/Standard/StringFieldTest.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace Parsing\Standard;
+
+use Mindee\Parsing\Standard\StringField;
+use PHPUnit\Framework\TestCase;
+
+class StringFieldTest extends TestCase
+{
+    public function testConstructor()
+    {
+        $fieldArray = [
+            "polygon" => [
+                [0.016, 0.707],
+                [0.414, 0.707],
+                [0.414, 0.831],
+                [0.016, 0.831]
+            ],
+            "confidence" => 0.1,
+            "value" => "some-value",
+        ];
+
+        $field = new StringField($fieldArray);
+        $this->assertEquals("some-value", $field->value);
+        $this->assertGreaterThan(0, count($field->boundingBox->getCoordinates()));
+    }
+
+    public function testConstructorFail()
+    {
+        $fieldArray = [
+            "polygon" => null,
+            "confidence" => 0.1,
+            "value" => "N/A",
+        ];
+
+        $field = new StringField($fieldArray);
+        $this->assertNull($field->value);
+    }
+}

--- a/tests/Parsing/Standard/TaxesTest.php
+++ b/tests/Parsing/Standard/TaxesTest.php
@@ -1,0 +1,58 @@
+<?php
+
+namespace Parsing\Standard;
+
+use Mindee\Parsing\Common\Ocr\Ocr;
+use Mindee\Parsing\Standard\Taxes;
+use Mindee\Parsing\Standard\TaxField;
+use PHPUnit\Framework\TestCase;
+
+class TaxesTest extends TestCase
+{
+    public function testConstructor()
+    {
+        $fieldArray = [
+            "value" => 2,
+            "rate" => 0.2,
+            "code" => "QST",
+            "confidence" => 0.1,
+            "polygon" => [[0.016, 0.707], [0.414, 0.707], [0.414, 0.831], [0.016, 0.831]],
+        ];
+        $tax = new TaxField($fieldArray);
+        $this->assertEquals(2, $tax->value);
+        $this->assertEquals(0.1, $tax->confidence);
+        $this->assertEquals(0.2, $tax->rate);
+        $this->assertGreaterThan(0, count($tax->boundingBox->getCoordinates()));
+        $this->assertEquals("Base: , Code: QST, Rate (%): 0.20, Amount: 2.00", strval($tax));
+    }
+
+    public function testConstructorNoRate(): void
+    {
+        $fieldDict = ["value" => 2.0, "confidence" => 0.1];
+        $tax = new TaxField($fieldDict);
+        $this->assertNull($tax->rate);
+        $this->assertNull($tax->boundingBox);
+        $this->assertEquals("Base: , Code: , Rate (%): , Amount: 2.00", (string)$tax);
+    }
+
+    public function testConstructorNoAmount(): void
+    {
+        $fieldDict = ["value" => "NA", "rate" => "AA", "code" => "N/A", "confidence" => 0.1];
+        $tax = new TaxField($fieldDict);
+        $this->assertNull($tax->value);
+        $this->assertEquals("Base: , Code: , Rate (%): , Amount:", (string)$tax);
+    }
+
+    public function testConstructorOnlyCode(): void
+    {
+        $fieldDict = [
+            "value" => "NA",
+            "rate" => "None",
+            "code" => "TAXES AND FEES",
+            "confidence" => 0.1,
+        ];
+        $tax = new TaxField($fieldDict);
+        $this->assertNull($tax->value);
+        $this->assertEquals("Base: , Code: TAXES AND FEES, Rate (%): , Amount:", (string)$tax);
+    }
+}

--- a/tests/Product/Custom/CustomV1LineItemsTest.php
+++ b/tests/Product/Custom/CustomV1LineItemsTest.php
@@ -1,0 +1,102 @@
+<?php
+
+namespace Product\Custom;
+
+use Mindee\Parsing\Common\Document;
+use Mindee\Parsing\Common\Page;
+use Mindee\Parsing\Common\Prediction;
+use Mindee\Product\Custom\CustomV1;
+use Mindee\Product\Custom\CustomV1Document;
+use Mindee\Product\Custom\CustomV1Page;
+use PHPUnit\Framework\TestCase;
+use Product\ProductSharedData;
+
+class CustomV1LineItemsTest extends TestCase
+{
+    private array $anchors;
+    private array $columns;
+    private Prediction $customV1LineItemsDocV1;
+    private Prediction $customV1LineItemsPage0V1;
+    private Prediction $customV1LineItemsDocV2;
+    private Prediction $customV1LineItemsPage0V2;
+
+    protected function setUp(): void
+    {
+        $jsonV1Complete = file_get_contents(
+            ProductSharedData::getProductDataDir() . "custom/response_v1/line_items/single_table_01.json"
+        );
+        $rawDataV1Complete = json_decode($jsonV1Complete, true);
+        $lineItemsDoc = new Document(CustomV1::class, $rawDataV1Complete["document"]);
+        $this->customV1LineItemsDocV1 = $lineItemsDoc->inference->prediction;
+        $page = new Page(
+            CustomV1Page::class,
+            $rawDataV1Complete["document"]["inference"]["pages"][0]
+        );
+        $this->customV1LineItemsPage0V1 = $page->prediction;
+
+        $jsonV1CompleteV2 = file_get_contents(
+            ProductSharedData::getProductDataDir() . "custom/response_v2/line_items/single_table_01.json"
+        );
+        $rawDataV1CompleteV2 = json_decode($jsonV1CompleteV2, true);
+        $lineItemsDocV2 = new Document(CustomV1::class, $rawDataV1CompleteV2["document"]);
+        $this->customV1LineItemsDocV2 = $lineItemsDocV2->inference->prediction;
+        $pageV2 = new Page(
+            CustomV1Page::class,
+            $rawDataV1CompleteV2["document"]["inference"]["pages"][0]
+        );
+        $this->customV1LineItemsPage0V2 = $pageV2->prediction;
+        $this->anchors = ["beneficiary_name"];
+        $this->columns = [
+            "beneficiary_birth_date",
+            "beneficiary_number",
+            "beneficiary_name",
+            "beneficiary_rank",
+        ];
+    }
+
+    public function testSingleTable01()
+    {
+        assert($this->customV1LineItemsDocV1 instanceof CustomV1Document);
+        $lineItemsDoc = $this->customV1LineItemsDocV1->columnsToLineItems($this->anchors, $this->columns, 0.011);
+        assert($this->customV1LineItemsPage0V1 instanceof CustomV1Page);
+        $lineItemsPage = $this->customV1LineItemsPage0V1->columnsToLineItems($this->anchors, $this->columns, 0.011);
+        foreach ([$lineItemsDoc, $lineItemsPage] as $lineItems) {
+            $this->assertEquals(3, count($lineItems));
+
+            $this->assertEquals("JAMES BOND 007", $lineItems[0]->fields["beneficiary_name"]->content);
+            $this->assertEquals("1970-11-11", $lineItems[0]->fields["beneficiary_birth_date"]->content);
+            $this->assertEquals(1, $lineItems[0]->rowNumber);
+
+            $this->assertEquals("HARRY POTTER", $lineItems[1]->fields["beneficiary_name"]->content);
+            $this->assertEquals("2010-07-18", $lineItems[1]->fields["beneficiary_birth_date"]->content);
+            $this->assertEquals(2, $lineItems[1]->rowNumber);
+
+            $this->assertEquals("DRAGO MALFOY", $lineItems[2]->fields["beneficiary_name"]->content);
+            $this->assertEquals("2015-07-05", $lineItems[2]->fields["beneficiary_birth_date"]->content);
+            $this->assertEquals(3, $lineItems[2]->rowNumber);
+        }
+    }
+
+    public function testSingleTable02()
+    {
+        assert($this->customV1LineItemsDocV2 instanceof CustomV1Document);
+        $lineItemsDoc = $this->customV1LineItemsDocV2->columnsToLineItems($this->anchors, $this->columns, 0.011);
+        assert($this->customV1LineItemsPage0V2 instanceof CustomV1Page);
+        $lineItemsPage = $this->customV1LineItemsPage0V2->columnsToLineItems($this->anchors, $this->columns, 0.011);
+        foreach ([$lineItemsDoc, $lineItemsPage] as $lineItems) {
+            $this->assertEquals(3, count($lineItems));
+
+            $this->assertEquals("JAMES BOND 007", $lineItems[0]->fields["beneficiary_name"]->content);
+            $this->assertEquals("1970-11-11", $lineItems[0]->fields["beneficiary_birth_date"]->content);
+            $this->assertEquals(1, $lineItems[0]->rowNumber);
+
+            $this->assertEquals("HARRY POTTER", $lineItems[1]->fields["beneficiary_name"]->content);
+            $this->assertEquals("2010-07-18", $lineItems[1]->fields["beneficiary_birth_date"]->content);
+            $this->assertEquals(2, $lineItems[1]->rowNumber);
+
+            $this->assertEquals("DRAGO MALFOY", $lineItems[2]->fields["beneficiary_name"]->content);
+            $this->assertEquals("2015-07-05", $lineItems[2]->fields["beneficiary_birth_date"]->content);
+            $this->assertEquals(3, $lineItems[2]->rowNumber);
+        }
+    }
+}

--- a/tests/Product/Custom/CustomV1Test.php
+++ b/tests/Product/Custom/CustomV1Test.php
@@ -1,0 +1,81 @@
+<?php
+
+namespace Product\Custom;
+
+use Mindee\Geometry\Polygon;
+use Mindee\Parsing\Common\Document;
+use Mindee\Parsing\Custom\ClassificationField;
+use Mindee\Parsing\Custom\ListField;
+use Mindee\Parsing\Custom\ListFieldValue;
+use Mindee\Product\Custom\CustomV1;
+use Mindee\Product\Custom\CustomV1Document;
+use PHPUnit\Framework\TestCase;
+use Product\ProductSharedData;
+
+require_once(__DIR__."/../ProductSharedData.php");
+
+class CustomV1Test extends TestCase
+{
+    public Document $customV1CompleteDoc;
+    public Document $customV1EmptyDoc;
+
+    protected function setUp(): void
+    {
+        $jsonV1Complete = file_get_contents(
+            ProductSharedData::getProductDataDir() . "custom/response_v1/complete.json"
+        );
+        $rawDataV1Complete = json_decode($jsonV1Complete, true);
+
+        $this->customV1CompleteDoc = new Document(CustomV1::class, $rawDataV1Complete["document"]);
+
+        $jsonV1Empty = file_get_contents(
+            ProductSharedData::getProductDataDir() . "custom/response_v1/empty.json"
+        );
+        $rawDataV1Empty = json_decode($jsonV1Empty, true);
+        $this->customV1EmptyDoc = new Document(CustomV1::class, $rawDataV1Empty["document"]);
+    }
+
+    public function testEmptyDoc(): void
+    {
+        $documentPrediction = $this->customV1EmptyDoc->inference->prediction;
+        assert($documentPrediction instanceof CustomV1Document);
+        foreach ($documentPrediction->fields as $fieldName => $field) {
+            $this->assertGreaterThan(0, strlen($fieldName));
+            $this->assertInstanceOf(ListField::class, $field);
+            $this->assertEquals(0, count($field->values));
+        }
+        foreach ($documentPrediction->classifications as $classificationName => $classification) {
+            $this->assertGreaterThan(0, strlen($classificationName));
+            $this->assertInstanceOf(ClassificationField::class, $classification);
+            $this->assertNull($classification->value);
+        }
+    }
+
+    public function testCompleteDoc()
+    {
+        $documentPrediction = $this->customV1CompleteDoc->inference->prediction;
+        assert($documentPrediction instanceof CustomV1Document);
+        $docStr = file_get_contents(ProductSharedData::getProductDataDir() . "custom/response_v1/summary_full.rst");
+        foreach ($documentPrediction->fields as $fieldName => $field) {
+            $this->assertGreaterThan(0, strlen($fieldName));
+            $this->assertInstanceOf(ListField::class, $field);
+            $this->assertGreaterThan(0, count($field->values));
+            $this->assertEquals(count($field->values), count($field->contentsList()));
+            foreach ($field->values as $value) {
+                $this->assertInstanceOf(ListFieldValue::class, $value);
+                $this->assertNotEquals("", $value->content);
+                {
+                    $this->assertInstanceOf(Polygon::class, $value->boundingBox);
+                    $this->assertEquals(4, count($value->boundingBox->getCoordinates()));
+                    $this->assertNotEquals(0.0, $value->confidence);
+                }
+            }
+        }
+        foreach ($documentPrediction->classifications as $classificationName => $classification) {
+            $this->assertNotEquals(0, strlen($classificationName));
+            $this->assertInstanceOf(ClassificationField::class, $classification);
+            $this->assertNotEquals("", $classification->value);
+        }
+        $this->assertEquals(strval($this->customV1CompleteDoc), $docStr);
+    }
+}

--- a/tests/Product/Custom/CustomV1V2Test.php
+++ b/tests/Product/Custom/CustomV1V2Test.php
@@ -1,0 +1,81 @@
+<?php
+
+namespace Product\Custom;
+
+use Mindee\Geometry\Polygon;
+use Mindee\Parsing\Common\Document;
+use Mindee\Parsing\Custom\ClassificationField;
+use Mindee\Parsing\Custom\ListField;
+use Mindee\Parsing\Custom\ListFieldValue;
+use Mindee\Product\Custom\CustomV1;
+use Mindee\Product\Custom\CustomV1Document;
+use PHPUnit\Framework\TestCase;
+use Product\ProductSharedData;
+
+require_once(__DIR__."/../ProductSharedData.php");
+
+class CustomV1V2Test extends TestCase
+{
+    public Document $customV1CompleteDoc;
+    public Document $customV1EmptyDoc;
+
+    protected function setUp(): void
+    {
+        $jsonV1Complete = file_get_contents(
+            ProductSharedData::getProductDataDir() . "custom/response_v2/complete.json"
+        );
+        $rawDataV1Complete = json_decode($jsonV1Complete, true);
+
+        $this->customV1CompleteDoc = new Document(CustomV1::class, $rawDataV1Complete["document"]);
+
+        $jsonV1Empty = file_get_contents(
+            ProductSharedData::getProductDataDir() . "custom/response_v2/empty.json"
+        );
+        $rawDataV1Empty = json_decode($jsonV1Empty, true);
+        $this->customV1EmptyDoc = new Document(CustomV1::class, $rawDataV1Empty["document"]);
+    }
+
+    public function testEmptyDoc(): void
+    {
+        $documentPrediction = $this->customV1EmptyDoc->inference->prediction;
+        assert($documentPrediction instanceof CustomV1Document);
+        foreach ($documentPrediction->fields as $fieldName => $field) {
+            $this->assertGreaterThan(0, strlen($fieldName));
+            $this->assertInstanceOf(ListField::class, $field);
+            $this->assertEquals(0, count($field->values));
+        }
+        foreach ($documentPrediction->classifications as $classificationName => $classification) {
+            $this->assertGreaterThan(0, strlen($classificationName));
+            $this->assertInstanceOf(ClassificationField::class, $classification);
+            $this->assertNull($classification->value);
+        }
+    }
+
+    public function testCompleteDoc()
+    {
+        $documentPrediction = $this->customV1CompleteDoc->inference->prediction;
+        assert($documentPrediction instanceof CustomV1Document);
+        $docStr = file_get_contents(ProductSharedData::getProductDataDir() . "custom/response_v2/summary_full.rst");
+        foreach ($documentPrediction->fields as $fieldName => $field) {
+            $this->assertGreaterThan(0, strlen($fieldName));
+            $this->assertInstanceOf(ListField::class, $field);
+            $this->assertGreaterThan(0, count($field->values));
+            $this->assertEquals(count($field->values), count($field->contentsList()));
+            foreach ($field->values as $value) {
+                $this->assertInstanceOf(ListFieldValue::class, $value);
+                $this->assertNotEquals("", $value->content);
+                {
+                    $this->assertInstanceOf(Polygon::class, $value->boundingBox);
+                    $this->assertEquals(4, count($value->boundingBox->getCoordinates()));
+                    $this->assertNotEquals(0.0, $value->confidence);
+                }
+            }
+        }
+        foreach ($documentPrediction->classifications as $classificationName => $classification) {
+            $this->assertNotEquals(0, strlen($classificationName));
+            $this->assertInstanceOf(ClassificationField::class, $classification);
+            $this->assertNotEquals("", $classification->value);
+        }
+        $this->assertEquals(strval($this->customV1CompleteDoc), $docStr);
+    }
+}

--- a/tests/Product/ProductSharedData.php
+++ b/tests/Product/ProductSharedData.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace Product;
+
+class ProductSharedData
+{
+    public static function getProductDataDir():string
+    {
+        return (getenv('GITHUB_WORKSPACE') ?: ".") . "/tests/resources/products/";
+    }
+}

--- a/tests/phpunit.xml
+++ b/tests/phpunit.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0"?>
+<phpunit bootstrap="../vendor/autoload.php">
+    <testsuites>
+        <testsuite name="main">
+            <directory suffix="Test.php">.</directory>
+        </testsuite>
+    </testsuites>
+    <logging/>
+</phpunit>


### PR DESCRIPTION
### Additions

* :sparkles: support for unit testing with phpunit
* :recycle: many internal fixes
* :wrench: switch doc build to macOS to circumvent issues in phpDocumentor's own dependency management
* :arrow_up: bump gh checkout action version
* :sparkles: add read_contents feature for local inputs