### PR TITLE
fix: Fatal error including API version string in a namespaced project

### DIFF
--- a/src/Http/MindeeApi.php
+++ b/src/Http/MindeeApi.php
@@ -35,7 +35,7 @@ const REQUEST_TIMEOUT_ENV_NAME = 'MINDEE_REQUEST_TIMEOUT';
  */
 const TIMEOUT_DEFAULT = 120;
 // phpcs:disable
-include_once('src/version.php');
+include_once(dirname(__DIR__) . '/version.php');
 // phpcs:enable
 const USER_AGENT = 'mindee-api-php@v' . VERSION . ' php-v' . PHP_VERSION . ' ' . PHP_OS;
 


### PR DESCRIPTION
## Description
Single-line change that fixes a 500 error (src/version.php not found) when using the library under Laravel and potentially other frameworks too.

## Reproduction
1. Install Laravel 10
2. Add mindee/mindee via composer
3. Attempt to use the API following the documentation from a Controller

## How Has This Been Tested
- PHP 8.1
- Ubuntu 22.04
- PHPStorm
- Followed reproduction steps

Also tested using the API after my proposed modifications via a simple script outside of Laravel. Works fine.


## Types of changes

- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires a change to the official Guide documentation.
