### PR TITLE
Bugfix - not sending the custom endpoint to parseQueued method

### DIFF
--- a/src/Client.php
+++ b/src/Client.php
@@ -366,7 +366,7 @@ class Client
             error_log("Polling server for parsing result with job id: " . $enqueueResponse->job->id);
             $retryCounter++;
             sleep($asyncOptions->delaySec);
-            $pollResults = $this->parseQueued($predictionType, $enqueueResponse->job->id);
+            $pollResults = $this->parseQueued($predictionType, $enqueueResponse->job->id, $options->endpoint);
         }
         if ($pollResults->job->status != "completed") {
             throw new MindeeApiException(


### PR DESCRIPTION


## Description
parseQueued function is not receiving the custom endpoint, so it is trying to construct an OTS and throws an exception: "Please create an endpoint manually before sending requests to a custom build."

## How Has This Been Tested
Calling my generated API endpoint

## Types of changes
- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires a change to the official Guide documentation.
