### PR TITLE
:recycle: Use "equal or greater" as symfony/console package restriction to allow SF6&7 packages

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -8,7 +8,7 @@
     "ext-curl": "*",
     "ext-fileinfo": "*",
     "ext-json": "*",
-    "symfony/console": "^5.4"
+    "symfony/console": ">=5.4"
   },
   "require-dev": {
     "friendsofphp/php-cs-fixer": "^3.38",


### PR DESCRIPTION
Right now the `^5.4` restriction blocks the ability to install the latest package version to SF 6 and SF7 apps where symfony/console is at `6.*` and `7.*` versions.

## Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->


## Related Issue
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->


## How Has This Been Tested
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires a change to the official Guide documentation.
