### PR TITLE
:sparkles: add support for webhooks & HMAC validation

### DIFF
--- a/src/Client.php
+++ b/src/Client.php
@@ -10,6 +10,7 @@ namespace Mindee;
 
 use Mindee\Error\MindeeApiException;
 use Mindee\Error\MindeeClientException;
+use Mindee\Error\MindeeException;
 use Mindee\Error\MindeeHttpException;
 use Mindee\Http\Endpoint;
 use Mindee\Http\MindeeApi;
@@ -20,6 +21,7 @@ use Mindee\Input\EnqueueAndParseMethodOptions;
 use Mindee\Input\FileInput;
 use Mindee\Input\InputSource;
 use Mindee\Input\LocalInputSource;
+use Mindee\Input\LocalResponse;
 use Mindee\Input\PageOptions;
 use Mindee\Input\PathInput;
 use Mindee\Input\PredictMethodOptions;
@@ -420,5 +422,27 @@ class Client
             $predictionType,
         );
         return $this->makeParseQueuedRequest($predictionType, $queueId, $endpoint);
+    }
+
+
+    /**
+     * @param string        $predictionType Name of the product's class.
+     * @param LocalResponse $localResponse  Local response to load.
+     * @return AsyncPredictResponse|PredictResponse A valid prediction response.
+     * @throws MindeeException Throws if the loaded response isn't a valid prediction.
+     */
+    public function loadPrediction(
+        string $predictionType,
+        LocalResponse $localResponse
+    ) {
+        try {
+            $json = $localResponse->toArray();
+            if (isset($json['job'])) {
+                return new AsyncPredictResponse($predictionType, $json);
+            }
+            return new PredictResponse($predictionType, $json);
+        } catch (\Exception $e) {
+            throw new MindeeException("Local response is not a valid prediction.");
+        }
     }
 }

--- a/src/Input/LocalResponse.php
+++ b/src/Input/LocalResponse.php
@@ -1,0 +1,102 @@
+<?php
+
+namespace Mindee\Input;
+
+use Mindee\Error\MindeeException;
+
+/**
+ * Local response loaded from a file.
+ */
+class LocalResponse
+{
+    /**
+     * @var mixed $file File object of the local response.
+     */
+    private $file;
+
+    /**
+     * @param mixed $inputFile A string, path or file-like object to load as a local response.
+     * @throws MindeeException Throws if the input file isn't acceptable.
+     */
+    public function __construct($inputFile)
+    {
+        if (is_resource($inputFile) && get_resource_type($inputFile) === 'file') {
+            $content = fread($inputFile, filesize($inputFile));
+            $strStripped = str_replace(["\r", "\n"], '', $content);
+            $this->file = fopen('php://memory', 'r+');
+            fwrite($this->file, $strStripped);
+            rewind($this->file);
+        } elseif (is_resource($inputFile) && get_resource_type($inputFile) === 'stream') {
+            $content = stream_get_contents($inputFile);
+            $strStripped = str_replace(["\r", "\n"], '', $content);
+            $this->file = fopen('php://memory', 'r+');
+            fwrite($this->file, $strStripped);
+            rewind($this->file);
+        } elseif (is_string($inputFile) && file_exists($inputFile)) {
+            $content = file_get_contents($inputFile);
+            $strStripped = str_replace(["\r", "\n"], '', $content);
+            $this->file = fopen('php://memory', 'r+');
+            fwrite($this->file, $strStripped);
+            rewind($this->file);
+        } elseif (is_string($inputFile)) {
+            $strStripped = str_replace(["\r", "\n"], '', $inputFile);
+            $this->file = fopen('php://memory', 'r+');
+            fwrite($this->file, $strStripped);
+            rewind($this->file);
+        } elseif (is_string($inputFile) || is_array($inputFile)) {
+            $strStripped = str_replace(["\r", "\n"], '', $inputFile);
+            $this->file = fopen('php://memory', 'r+');
+            fwrite($this->file, $strStripped);
+            rewind($this->file);
+        } else {
+            throw new MindeeException("Incompatible type for input.");
+        }
+    }
+
+    /**
+     * @return array
+     * @throws MindeeException Throws if the file contents cannot be converted to a valid array.
+     */
+    public function toArray(): array
+    {
+        try {
+            rewind($this->file);
+            $content = stream_get_contents($this->file);
+            $json = json_decode($content, true);
+            if (json_last_error() !== JSON_ERROR_NONE) {
+                throw new MindeeException("File is not a valid dictionary.");
+            }
+            return $json;
+        } catch (MindeeException $e) {
+            throw new MindeeException("File is not a valid dictionary.", 0, $e);
+        }
+    }
+
+    /**
+     * @param string $secretKey Secret key as a string.
+     * @return string a valid HMAC signature
+     * @throws MindeeException Throws when either the file is unreadable, or when the secret is invalid.
+     */
+    public function getHMACSignature(string $secretKey): string
+    {
+        $algorithm = 'sha256';
+
+        try {
+            rewind($this->file);
+            $content = stream_get_contents($this->file);
+            return hash_hmac($algorithm, $content, $secretKey);
+        } catch (MindeeException $e) {
+            throw new MindeeException("Could not get HMAC signature from payload.", 0, $e);
+        }
+    }
+
+    /**
+     * @param string $secretKey Secret, given key as a string.
+     * @param string $signature HMAC signature as a string.
+     * @return boolean
+     */
+    public function isValidHMACSignature(string $secretKey, string $signature): bool
+    {
+        return $signature === $this->getHMACSignature($secretKey);
+    }
+}

--- a/tests/ClientTest.php
+++ b/tests/ClientTest.php
@@ -5,6 +5,7 @@ use Mindee\Error\MindeeApiException;
 use Mindee\Error\MindeeHttpClientException;
 use Mindee\Error\MindeeHttpException;
 use Mindee\Input\EnqueueAndParseMethodOptions;
+use Mindee\Input\LocalResponse;
 use Mindee\Input\PageOptions;
 use Mindee\Input\PredictMethodOptions;
 use Mindee\Product\Custom\CustomV1;
@@ -19,6 +20,7 @@ class ClientTest extends TestCase
     private Client $envClient;
     private string $oldKey;
     private string $fileTypesDir;
+    private string $invoicePath;
 
 
     protected function setUp(): void
@@ -32,6 +34,9 @@ class ClientTest extends TestCase
         $this->fileTypesDir = (
             getenv('GITHUB_WORKSPACE') ?: "."
             ) . "/tests/resources/file_types/";
+        $this->invoicePath = (
+            getenv('GITHUB_WORKSPACE') ?: "."
+            ) . "/tests/resources/products/invoices/response_v4/complete.json";
     }
 
 
@@ -117,5 +122,11 @@ class ClientTest extends TestCase
         $this->dummyClient->parse(InvoiceV4::class, $inputDoc, $predictOptions);
         $this->expectException(MindeeHttpClientException::class);
         $this->dummyClient->enqueue(InvoiceSplitterV1::class, $inputDoc, $predictOptions);
+    }
+
+    public function testLoadLocalResponse(){
+        $localResponse = new LocalResponse($this->invoicePath);
+        $res = $this->dummyClient->loadPrediction(InvoiceV4::class, $localResponse);
+        $this->assertNotNull($res);
     }
 }

--- a/tests/Input/LocalResponseTest.php
+++ b/tests/Input/LocalResponseTest.php
@@ -1,0 +1,130 @@
+<?php
+
+namespace Input;
+
+use Mindee\Input\LocalResponse;
+use PHPUnit\Framework\TestCase;
+
+class LocalResponseTest extends TestCase {
+    private string $signature;
+    private string $dummyKey;
+    private string $filePath;
+
+    protected function setUp(): void {
+        $this->filePath = (getenv('GITHUB_WORKSPACE') ?: ".") . "/tests/resources/async/get_completed_empty.json";
+        $this->signature = "5ed1673e34421217a5dbfcad905ee62261a3dd66c442f3edd19302072bbf70d0";
+        $this->dummyKey = "ogNjY44MhvKPGTtVsI8zG82JqWQa68woYQH";
+    }
+
+    public function testValidFileLocalResponse()
+    {
+        $file = fopen($this->filePath, 'rb');
+        $localResponse = new LocalResponse($file);
+        fclose($file);
+
+        $this->assertNotNull($localResponse->toArray(), 'Local response file should not be null');
+
+        $invalidSignature = 'invalid_signature';
+        $this->assertFalse(
+            $localResponse->isValidHmacSignature($this->dummyKey, $invalidSignature),
+            'Invalid signature should not be valid'
+        );
+
+        $calculatedSignature = $localResponse->getHmacSignature($this->dummyKey);
+        $this->assertEquals(
+            $this->signature,
+            $calculatedSignature,
+            'Calculated signature should match the expected valid signature'
+        );
+
+        $this->assertTrue(
+            $localResponse->isValidHmacSignature($this->dummyKey, $this->signature),
+            'Valid signature should be valid'
+        );
+    }
+
+    public function testValidStringLocalResponse()
+    {
+        $file = file_get_contents($this->filePath);
+        $localResponse = new LocalResponse($file);
+
+        $this->assertNotNull($localResponse->toArray(), 'Local response file should not be null');
+
+        $invalidSignature = 'invalid_signature';
+        $this->assertFalse(
+            $localResponse->isValidHmacSignature($this->dummyKey, $invalidSignature),
+            'Invalid signature should not be valid'
+        );
+
+        $calculatedSignature = $localResponse->getHmacSignature($this->dummyKey);
+        $this->assertEquals(
+            $this->signature,
+            $calculatedSignature,
+            'Calculated signature should match the expected valid signature'
+        );
+
+        $this->assertTrue(
+            $localResponse->isValidHmacSignature($this->dummyKey, $this->signature),
+            'Valid signature should be valid'
+        );
+    }
+
+
+    public function testValidStreamLocalResponse()
+    {
+        // Create a stream from the file content
+        $stream = fopen('php://memory', 'r+');
+        fwrite($stream, file_get_contents($this->filePath));
+        rewind($stream);
+
+        // Create LocalResponse instance with the stream
+        $localResponse = new LocalResponse($stream);
+
+        $this->assertNotNull($localResponse->toArray(), 'Local response file should not be null');
+
+        $invalidSignature = 'invalid_signature';
+        $this->assertFalse(
+            $localResponse->isValidHmacSignature($this->dummyKey, $invalidSignature),
+            'Invalid signature should not be valid'
+        );
+
+        $calculatedSignature = $localResponse->getHmacSignature($this->dummyKey);
+        $this->assertEquals(
+            $this->signature,
+            $calculatedSignature,
+            'Calculated signature should match the expected valid signature'
+        );
+
+        $this->assertTrue(
+            $localResponse->isValidHmacSignature($this->dummyKey, $this->signature),
+            'Valid signature should be valid'
+        );
+
+        fclose($stream); // Close the stream after use
+    }
+    
+    public function testValidFilePathLocalResponse()
+    {
+        $localResponse = new LocalResponse($this->filePath);
+
+        $this->assertNotNull($localResponse->toArray(), 'Local response file should not be null');
+
+        $invalidSignature = 'invalid_signature';
+        $this->assertFalse(
+            $localResponse->isValidHmacSignature($this->dummyKey, $invalidSignature),
+            'Invalid signature should not be valid'
+        );
+
+        $calculatedSignature = $localResponse->getHmacSignature($this->dummyKey);
+        $this->assertEquals(
+            $this->signature,
+            $calculatedSignature,
+            'Calculated signat match the expected valid signature'
+        );
+
+        $this->assertTrue(
+            $localResponse->isValidHmacSignature($this->dummyKey, $this->signature),
+            'Valid signature should be valid'
+        );
+    }
+}


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
* :sparkles: add support for local response loading (webhooks)
* :sparkles: add support for HMAC validation

## Related Issue
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->


## How Has This Been Tested
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires a change to the official Guide documentation.
