### PR TITLE
Add check for null before passing available_at field to strtotime

### DIFF
--- a/src/Parsing/Common/Job.php
+++ b/src/Parsing/Common/Job.php
@@ -58,7 +58,7 @@ class Job
         }
         $this->id = $rawResponse['id'];
         $this->status = $rawResponse['status'];
-        if (array_key_exists('available_at', $rawResponse) && null !== $rawResponse['available_at'] && strtotime($rawResponse['available_at'])) {
+        if (array_key_exists('available_at', $rawResponse) && $rawResponse['available_at'] !== null && strtotime($rawResponse['available_at'])) {
             try {
                 $this->availableAt = new DateTimeImmutable($rawResponse['available_at']);
             } catch (\Exception $e) {


### PR DESCRIPTION
When running in `declare(strict_type=1)` mode, a deprication notice is being triggered, which in our case triggers an error:

Deprecated: strtotime(): Passing null to parameter #1 ($datetime) of type string is deprecated

This PR adds a check for null before passing the field to strtotime. 

- [x] Bug fix (non-breaking change which fixes an issue)